### PR TITLE
make it a little closer suit for Unity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,3 +267,4 @@ artifacts/
 artifacts-*/
 
 build/*
+src/JoltPhysicsSharp/runtimes/

--- a/src/JoltPhysicsSharp/ActivationMode.cs
+++ b/src/JoltPhysicsSharp/ActivationMode.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/Body.cs
+++ b/src/JoltPhysicsSharp/Body.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/BodyCreationSettings.cs
+++ b/src/JoltPhysicsSharp/BodyCreationSettings.cs
@@ -1,4 +1,4 @@
-﻿// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/BodyCreationSettings.cs
+++ b/src/JoltPhysicsSharp/BodyCreationSettings.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+ï»¿// Copyright ï¿½ Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/BodyID.cs
+++ b/src/JoltPhysicsSharp/BodyID.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/BodyInterface.cs
+++ b/src/JoltPhysicsSharp/BodyInterface.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/BroadPhaseLayer.cs
+++ b/src/JoltPhysicsSharp/BroadPhaseLayer.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/BroadPhaseLayerInterface.cs
+++ b/src/JoltPhysicsSharp/BroadPhaseLayerInterface.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/JoltPhysicsSharp/BroadPhaseLayerInterface.cs
+++ b/src/JoltPhysicsSharp/BroadPhaseLayerInterface.cs
@@ -14,13 +14,14 @@ public abstract class BroadPhaseLayerInterface : NativeObject
 
     static unsafe BroadPhaseLayerInterface()
     {
-        s_broadPhaseLayerInterface_Procs = new JPH_BroadPhaseLayerInterface_Procs
+        JPH_BroadPhaseLayerInterface_Procs broadPhaseLayerInterface_Procs = new()
         {
             GetNumBroadPhaseLayers = &GetNumBroadPhaseLayersCallback,
             GetBroadPhaseLayer = &GetBroadPhaseLayerCallback,
             GetBroadPhaseLayerName= &GetBroadPhaseLayerNameCallback
         };
-        JPH_BroadPhaseLayerInterface_SetProcs(s_broadPhaseLayerInterface_Procs);
+        JPH_BroadPhaseLayerInterface_SetProcs(&broadPhaseLayerInterface_Procs);
+        s_broadPhaseLayerInterface_Procs = broadPhaseLayerInterface_Procs;
     }
 
     public BroadPhaseLayerInterface()

--- a/src/JoltPhysicsSharp/ConstraintSpace.cs
+++ b/src/JoltPhysicsSharp/ConstraintSpace.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/Constraints/Constraint.cs
+++ b/src/JoltPhysicsSharp/Constraints/Constraint.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Constraints/PointConstraint.cs
+++ b/src/JoltPhysicsSharp/Constraints/PointConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Constraints/TwoBodyConstraint.cs
+++ b/src/JoltPhysicsSharp/Constraints/TwoBodyConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/DisposableObject.cs
+++ b/src/JoltPhysicsSharp/DisposableObject.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/JoltPhysicsSharp/DisposableObject.cs
+++ b/src/JoltPhysicsSharp/DisposableObject.cs
@@ -8,7 +8,7 @@ namespace JoltPhysicsSharp;
 /// <summary>An object which is disposable.</summary>
 public abstract class DisposableObject : IDisposable
 {
-    private volatile uint _isDisposed;
+    private volatile int _isDisposed;
 
     /// <summary>Initializes a new instance of the <see cref="DisposableObject" /> class.</summary>
     protected DisposableObject()

--- a/src/JoltPhysicsSharp/DisposableObject.cs
+++ b/src/JoltPhysicsSharp/DisposableObject.cs
@@ -40,7 +40,7 @@ public abstract class DisposableObject : IDisposable
     {
         if (_isDisposed != 0)
         {
-            new ObjectDisposedException(GetType().Name);
+            throw new ObjectDisposedException(GetType().Name);
         }
     }
 

--- a/src/JoltPhysicsSharp/Foundation.cs
+++ b/src/JoltPhysicsSharp/Foundation.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/IndexedTriangle.cs
+++ b/src/JoltPhysicsSharp/IndexedTriangle.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/IndexedTriangleNoMaterial.cs
+++ b/src/JoltPhysicsSharp/IndexedTriangleNoMaterial.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/JobSystemThreadPool.cs
+++ b/src/JoltPhysicsSharp/JobSystemThreadPool.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -10,7 +10,7 @@ namespace JoltPhysicsSharp;
 internal static unsafe partial class JoltApi
 {
     private const string LibName = "joltc";
-
+#if NET
     static JoltApi()
     {
         NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), OnDllImport);
@@ -84,7 +84,7 @@ internal static unsafe partial class JoltApi
         nativeLibrary = IntPtr.Zero;
         return false;
     }
-
+#endif
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern uint JPH_Init();

--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -117,7 +117,7 @@ internal static unsafe partial class JoltApi
     }
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern void JPH_BroadPhaseLayerInterface_SetProcs(JPH_BroadPhaseLayerInterface_Procs procs);
+    public static extern void JPH_BroadPhaseLayerInterface_SetProcs(JPH_BroadPhaseLayerInterface_Procs* procs);
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr JPH_BroadPhaseLayerInterface_Create();
@@ -518,7 +518,7 @@ internal static unsafe partial class JoltApi
     }
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern void JPH_ContactListener_SetProcs(JPH_ContactListener_Procs procs);
+    public static extern void JPH_ContactListener_SetProcs(JPH_ContactListener_Procs* procs);
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr JPH_ContactListener_Create();
@@ -534,7 +534,7 @@ internal static unsafe partial class JoltApi
     }
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern void JPH_BodyActivationListener_SetProcs(JPH_BodyActivationListener_Procs procs);
+    public static extern void JPH_BodyActivationListener_SetProcs(JPH_BodyActivationListener_Procs* procs);
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr JPH_BodyActivationListener_Create();

--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/MotionType.cs
+++ b/src/JoltPhysicsSharp/MotionType.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/NativeObject.cs
+++ b/src/JoltPhysicsSharp/NativeObject.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/ObjectLayer.cs
+++ b/src/JoltPhysicsSharp/ObjectLayer.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/ObjectLayerPairFilter.cs
+++ b/src/JoltPhysicsSharp/ObjectLayerPairFilter.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/JoltPhysicsSharp/ObjectVsBroadPhaseLayerFilter.cs
+++ b/src/JoltPhysicsSharp/ObjectVsBroadPhaseLayerFilter.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/JoltPhysicsSharp/ObjectVsBroadPhaseLayerFilter.cs
+++ b/src/JoltPhysicsSharp/ObjectVsBroadPhaseLayerFilter.cs
@@ -10,15 +10,15 @@ namespace JoltPhysicsSharp;
 public abstract class ObjectVsBroadPhaseLayerFilter : NativeObject
 {
     private static readonly Dictionary<IntPtr, ObjectVsBroadPhaseLayerFilter> s_listeners = new();
-    private static JPH_ObjectVsBroadPhaseLayerFilter_Procs s_ObjectVsBroadPhaseLayerFilter_Procs;
+    private static JPH_ObjectVsBroadPhaseLayerFilter_Procs s_objectVsBroadPhaseLayerFilter_Procs;
 
     static unsafe ObjectVsBroadPhaseLayerFilter()
     {
-        s_ObjectVsBroadPhaseLayerFilter_Procs = new JPH_ObjectVsBroadPhaseLayerFilter_Procs
+        s_objectVsBroadPhaseLayerFilter_Procs = new JPH_ObjectVsBroadPhaseLayerFilter_Procs
         {
             ShouldCollide = &ShouldCollideCallback
         };
-        JPH_ObjectVsBroadPhaseLayerFilter_SetProcs(s_ObjectVsBroadPhaseLayerFilter_Procs);
+        JPH_ObjectVsBroadPhaseLayerFilter_SetProcs(s_objectVsBroadPhaseLayerFilter_Procs);
     }
 
     public ObjectVsBroadPhaseLayerFilter()

--- a/src/JoltPhysicsSharp/PhysicsSystem.cs
+++ b/src/JoltPhysicsSharp/PhysicsSystem.cs
@@ -26,25 +26,26 @@ public sealed class PhysicsSystem : NativeObject
 
     static unsafe PhysicsSystem()
     {
-        s_contactListener_Procs = new JPH_ContactListener_Procs
+        JPH_ContactListener_Procs contactListener_Procs = new()
         {
             OnContactValidate = &OnContactValidateCallback,
             OnContactAdded = &OnContactAddedCallback,
             OnContactPersisted = &OnContactPersistedCallback,
             OnContactRemoved = &OnContactRemovedCallback
         };
-        JPH_ContactListener_SetProcs(s_contactListener_Procs);
+        JPH_ContactListener_SetProcs(&contactListener_Procs);
+        s_contactListener_Procs = contactListener_Procs;
 
-        s_bodyActivationListener_Procs = new JPH_BodyActivationListener_Procs
+        JPH_BodyActivationListener_Procs bodyActivationListener_Procs = new()
         {
             OnBodyActivated = &OnBodyActivatedCallback,
             OnBodyDeactivated = &OnBodyDeactivatedCallback
         };
-        JPH_BodyActivationListener_SetProcs(s_bodyActivationListener_Procs);
+        JPH_BodyActivationListener_SetProcs(&bodyActivationListener_Procs);
+        s_bodyActivationListener_Procs = bodyActivationListener_Procs;
     }
 
-    public PhysicsSystem()
-        : base(JPH_PhysicsSystem_Create())
+    public PhysicsSystem() : base(JPH_PhysicsSystem_Create())
     {
         _contactListenerHandle = JPH_ContactListener_Create();
         s_contactListeners.Add(_contactListenerHandle, this);

--- a/src/JoltPhysicsSharp/PhysicsSystem.cs
+++ b/src/JoltPhysicsSharp/PhysicsSystem.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/PhysicsSystem.cs
+++ b/src/JoltPhysicsSharp/PhysicsSystem.cs
@@ -19,10 +19,10 @@ public sealed class PhysicsSystem : NativeObject
     private static readonly Dictionary<IntPtr, PhysicsSystem> s_contactListeners = new();
     private static readonly Dictionary<IntPtr, PhysicsSystem> s_bodyActivationListenerListeners = new();
     private static readonly JPH_ContactListener_Procs s_contactListener_Procs;
-    private static readonly JPH_BodyActivationListener_Procs s_BodyActivationListener_Procs;
+    private static readonly JPH_BodyActivationListener_Procs s_bodyActivationListener_Procs;
 
-    private readonly IntPtr contactListenerHandle;
-    private readonly IntPtr bodyActivationListenerHandle;
+    private readonly IntPtr _contactListenerHandle;
+    private readonly IntPtr _bodyActivationListenerHandle;
 
     static unsafe PhysicsSystem()
     {
@@ -35,25 +35,25 @@ public sealed class PhysicsSystem : NativeObject
         };
         JPH_ContactListener_SetProcs(s_contactListener_Procs);
 
-        s_BodyActivationListener_Procs = new JPH_BodyActivationListener_Procs
+        s_bodyActivationListener_Procs = new JPH_BodyActivationListener_Procs
         {
             OnBodyActivated = &OnBodyActivatedCallback,
             OnBodyDeactivated = &OnBodyDeactivatedCallback
         };
-        JPH_BodyActivationListener_SetProcs(s_BodyActivationListener_Procs);
+        JPH_BodyActivationListener_SetProcs(s_bodyActivationListener_Procs);
     }
 
     public PhysicsSystem()
         : base(JPH_PhysicsSystem_Create())
     {
-        contactListenerHandle = JPH_ContactListener_Create();
-        s_contactListeners.Add(contactListenerHandle, this);
+        _contactListenerHandle = JPH_ContactListener_Create();
+        s_contactListeners.Add(_contactListenerHandle, this);
 
-        bodyActivationListenerHandle = JPH_BodyActivationListener_Create();
-        s_bodyActivationListenerListeners.Add(bodyActivationListenerHandle, this);
+        _bodyActivationListenerHandle = JPH_BodyActivationListener_Create();
+        s_bodyActivationListenerListeners.Add(_bodyActivationListenerHandle, this);
 
-        JPH_PhysicsSystem_SetContactListener(Handle, contactListenerHandle);
-        JPH_PhysicsSystem_SetBodyActivationListener(Handle, bodyActivationListenerHandle);
+        JPH_PhysicsSystem_SetContactListener(Handle, _contactListenerHandle);
+        JPH_PhysicsSystem_SetBodyActivationListener(Handle, _bodyActivationListenerHandle);
     }
 
     /// <summary>
@@ -65,11 +65,11 @@ public sealed class PhysicsSystem : NativeObject
     {
         if (isDisposing)
         {
-            s_contactListeners.Remove(contactListenerHandle);
-            JPH_ContactListener_Destroy(contactListenerHandle);
+            s_contactListeners.Remove(_contactListenerHandle);
+            JPH_ContactListener_Destroy(_contactListenerHandle);
 
-            s_bodyActivationListenerListeners.Remove(bodyActivationListenerHandle);
-            JPH_BodyActivationListener_Destroy(bodyActivationListenerHandle);
+            s_bodyActivationListenerListeners.Remove(_bodyActivationListenerHandle);
+            JPH_BodyActivationListener_Destroy(_bodyActivationListenerHandle);
 
             JPH_PhysicsSystem_Destroy(Handle);
         }
@@ -242,7 +242,7 @@ public sealed class PhysicsSystem : NativeObject
     }
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
-    private unsafe static void OnContactRemovedCallback(IntPtr listenerPtr, SubShapeIDPair* subShapePair)
+    private static unsafe void OnContactRemovedCallback(IntPtr listenerPtr, SubShapeIDPair* subShapePair)
     {
         PhysicsSystem listener = s_contactListeners[listenerPtr];
         listener.OnContactRemoved?.Invoke(listener, ref Unsafe.AsRef<SubShapeIDPair>(subShapePair));

--- a/src/JoltPhysicsSharp/Shape/BoxShape.cs
+++ b/src/JoltPhysicsSharp/Shape/BoxShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/CapsuleShape.cs
+++ b/src/JoltPhysicsSharp/Shape/CapsuleShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/CompoundShape.cs
+++ b/src/JoltPhysicsSharp/Shape/CompoundShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/ConvexHullShape.cs
+++ b/src/JoltPhysicsSharp/Shape/ConvexHullShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/ConvexShape.cs
+++ b/src/JoltPhysicsSharp/Shape/ConvexShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/CylinderShape.cs
+++ b/src/JoltPhysicsSharp/Shape/CylinderShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/HeightFieldShape.cs
+++ b/src/JoltPhysicsSharp/Shape/HeightFieldShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/MeshShape.cs
+++ b/src/JoltPhysicsSharp/Shape/MeshShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/MutableCompoundShape.cs
+++ b/src/JoltPhysicsSharp/Shape/MutableCompoundShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/Shape.cs
+++ b/src/JoltPhysicsSharp/Shape/Shape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/SphereShape.cs
+++ b/src/JoltPhysicsSharp/Shape/SphereShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/StaticCompoundShape.cs
+++ b/src/JoltPhysicsSharp/Shape/StaticCompoundShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/TaperedCapsuleShape.cs
+++ b/src/JoltPhysicsSharp/Shape/TaperedCapsuleShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/TriangleShape.cs
+++ b/src/JoltPhysicsSharp/Shape/TriangleShape.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/SubShapeIDPair.cs
+++ b/src/JoltPhysicsSharp/SubShapeIDPair.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/TempAllocator.cs
+++ b/src/JoltPhysicsSharp/TempAllocator.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Triangle.cs
+++ b/src/JoltPhysicsSharp/Triangle.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/ValidateResult.cs
+++ b/src/JoltPhysicsSharp/ValidateResult.cs
@@ -1,4 +1,4 @@
-// Copyright � Amer Koleci and Contributors.
+﻿// Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/joltc/ExternLog.cpp
+++ b/src/joltc/ExternLog.cpp
@@ -1,0 +1,20 @@
+#include "ExternLog.hpp"
+//#include <iostream>
+
+void ExternLog(const char* message)
+{
+    if (ExternLogFunc)
+        ExternLogFunc(message);
+    //else std::cout << message << std::endl;
+}
+
+void InitLogger(void(_cdecl* Log)(const char* message))
+{
+    if (!Log)
+    {
+        //std::cout << "InitLogger func pointer should not be null" << std::endl;
+        return;
+    }
+    ExternLogFunc = Log;
+    ExternLog("Cpp Message: Log has initialized");
+}

--- a/src/joltc/ExternLog.hpp
+++ b/src/joltc/ExternLog.hpp
@@ -1,25 +1,9 @@
 //used for logging message from native to managed side
 #pragma once
-#include <iostream>
 
 static void(_cdecl* ExternLogFunc)(const char* message);
 
 //use this in source code to send message to extern
-extern "C" void _declspec(dllexport) ExternLog(const char* message)
-{
-    if (ExternLogFunc)
-        ExternLogFunc(message);
-    else
-        std::cout << message << std::endl;
-}
+void ExternLog(const char* message);
 
-extern "C" void _declspec(dllexport) InitLogger(void(_cdecl* Log)(const char* message))
-{
-    if (!Log)
-    {
-        std::cout << "InitLogger func pointer should not be null" << std::endl;
-        return;
-    }
-    ExternLogFunc = Log;
-    ExternLog("Cpp Message: Log has initialized");
-}
+extern "C" void _declspec(dllexport) InitLogger(void(_cdecl * Log)(const char* message));

--- a/src/joltc/ExternLog.hpp
+++ b/src/joltc/ExternLog.hpp
@@ -1,0 +1,25 @@
+//used for logging message from native to managed side
+#pragma once
+#include <iostream>
+
+static void(_cdecl* ExternLogFunc)(const char* message);
+
+//use this in source code to send message to extern
+extern "C" void _declspec(dllexport) ExternLog(const char* message)
+{
+    if (ExternLogFunc)
+        ExternLogFunc(message);
+    else
+        std::cout << message << std::endl;
+}
+
+extern "C" void _declspec(dllexport) InitLogger(void(_cdecl* Log)(const char* message))
+{
+    if (!Log)
+    {
+        std::cout << "InitLogger func pointer should not be null" << std::endl;
+        return;
+    }
+    ExternLogFunc = Log;
+    ExternLog("Cpp Message: Log has initialized");
+}

--- a/src/joltc/int_to_hex.h
+++ b/src/joltc/int_to_hex.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+template<typename T>
+std::string int_to_hex_str(T i)
+{
+    std::stringstream str{};
+    str << "0x" << std::setfill('0') << std::setw(sizeof(T) * 2) << std::hex << i;
+    return str.str();
+}

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -254,9 +254,9 @@ public:
 #endif // JPH_EXTERNAL_PROFILE || JPH_PROFILE_ENABLED
 };
 
-void JPH_BroadPhaseLayerInterface_SetProcs(JPH_BroadPhaseLayerInterface_Procs procs)
+void JPH_BroadPhaseLayerInterface_SetProcs(JPH_BroadPhaseLayerInterface_Procs* procs)
 {
-    g_BroadPhaseLayerInterface_Procs = procs;
+    g_BroadPhaseLayerInterface_Procs = *procs;
 }
 
 JPH_BroadPhaseLayerInterface* JPH_BroadPhaseLayerInterface_Create()
@@ -1293,9 +1293,9 @@ public:
     }
 };
 
-void JPH_ContactListener_SetProcs(JPH_ContactListener_Procs procs)
+void JPH_ContactListener_SetProcs(JPH_ContactListener_Procs* procs)
 {
-    g_ContactListener_Procs = procs;
+    g_ContactListener_Procs = *procs;
 }
 
 JPH_ContactListener* JPH_ContactListener_Create()
@@ -1337,9 +1337,9 @@ public:
     }
 };
 
-void JPH_BodyActivationListener_SetProcs(JPH_BodyActivationListener_Procs procs)
+void JPH_BodyActivationListener_SetProcs(JPH_BodyActivationListener_Procs* procs)
 {
-    g_BodyActivationListener_Procs = procs;
+    g_BodyActivationListener_Procs = *procs;
 }
 
 JPH_BodyActivationListener* JPH_BodyActivationListener_Create()

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -382,7 +382,7 @@ typedef struct JPH_BroadPhaseLayerInterface_Procs {
     const char* (*GetBroadPhaseLayerName)(const JPH_BroadPhaseLayerInterface* interface, JPH_BroadPhaseLayer layer);
 } JPH_BroadPhaseLayerInterface_Procs;
 
-JPH_CAPI void JPH_BroadPhaseLayerInterface_SetProcs(JPH_BroadPhaseLayerInterface_Procs procs);
+JPH_CAPI void JPH_BroadPhaseLayerInterface_SetProcs(JPH_BroadPhaseLayerInterface_Procs* procs);
 JPH_CAPI JPH_BroadPhaseLayerInterface* JPH_BroadPhaseLayerInterface_Create();
 JPH_CAPI void JPH_BroadPhaseLayerInterface_Destroy(JPH_BroadPhaseLayerInterface* layer);
 
@@ -425,7 +425,7 @@ typedef struct JPH_ContactListener_Procs {
         );
 } JPH_ContactListener_Procs;
 
-JPH_CAPI void JPH_ContactListener_SetProcs(JPH_ContactListener_Procs procs);
+JPH_CAPI void JPH_ContactListener_SetProcs(JPH_ContactListener_Procs* procs);
 JPH_CAPI JPH_ContactListener* JPH_ContactListener_Create();
 JPH_CAPI void JPH_ContactListener_Destroy(JPH_ContactListener* listener);
 
@@ -435,7 +435,7 @@ typedef struct JPH_BodyActivationListener_Procs {
     void(JPH_API_CALL* OnBodyDeactivated)(JPH_BodyActivationListener* listener, JPH_BodyID bodyID, uint64_t bodyUserData);
 } JPH_BodyActivationListener_Procs;
 
-JPH_CAPI void JPH_BodyActivationListener_SetProcs(JPH_BodyActivationListener_Procs procs);
+JPH_CAPI void JPH_BodyActivationListener_SetProcs(JPH_BodyActivationListener_Procs* procs);
 JPH_CAPI JPH_BodyActivationListener* JPH_BodyActivationListener_Create();
 JPH_CAPI void JPH_BodyActivationListener_Destroy(JPH_BodyActivationListener* listener);
 

--- a/src/samples/HelloWorld/Program.cs
+++ b/src/samples/HelloWorld/Program.cs
@@ -100,7 +100,7 @@ public static class Program
         }
     }
 
-    private static float WorldScale = 1.0f;
+    private const float WorldScale = 1.0f;
 
     private static Body CreateFloor(in BodyInterface bodyInterface, float size = 200.0f)
     {


### PR DESCRIPTION
Hi amerkoleci, I'm a indepedent game developer, and trying to make a space war simulator. This pull request are just some small detail improvements. It's a pity that I finally running successfully in unity, but for some unknown reason, just copy a empty [UnmanagedCallersOnly] Attribute from .NET7 source code works for my test dll callback from C#, but not work for joltc, and always cause Unity crash. So I changed to [MonoPInvoke] attribute which only works in Unity, and I can no longer use '&' to get unmanaged function pointer, changed to Marshal.GetFunctionPointerForDelegate. These are only in my Unity test project, not in this pull request cause it's not compatible with .Net6/7(or change function pointer declare to "IntPtr" instead of "delegate* unmanaged XXXX", and use # branch compile to use [MonoPInvoke] and [UnmanagedCallersOnly] in different compile platform, my ugly workaround thought). If you like, I can show you all my change in unity, and there should be a better resolution which I don't know. On next step, I'll try to make it compatible with JoltPhysics double precision compile mode.