### PR TITLE
change .cs encoding to UTF-8

### DIFF
--- a/src/JoltPhysicsSharp/ActivationMode.cs
+++ b/src/JoltPhysicsSharp/ActivationMode.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/Body.cs
+++ b/src/JoltPhysicsSharp/Body.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/BodyCreationSettings.cs
+++ b/src/JoltPhysicsSharp/BodyCreationSettings.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/BodyID.cs
+++ b/src/JoltPhysicsSharp/BodyID.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/BodyInterface.cs
+++ b/src/JoltPhysicsSharp/BodyInterface.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/BroadPhaseLayer.cs
+++ b/src/JoltPhysicsSharp/BroadPhaseLayer.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/BroadPhaseLayerInterface.cs
+++ b/src/JoltPhysicsSharp/BroadPhaseLayerInterface.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/JoltPhysicsSharp/ConstraintSpace.cs
+++ b/src/JoltPhysicsSharp/ConstraintSpace.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/Constraints/Constraint.cs
+++ b/src/JoltPhysicsSharp/Constraints/Constraint.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Constraints/PointConstraint.cs
+++ b/src/JoltPhysicsSharp/Constraints/PointConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Constraints/TwoBodyConstraint.cs
+++ b/src/JoltPhysicsSharp/Constraints/TwoBodyConstraint.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/DisposableObject.cs
+++ b/src/JoltPhysicsSharp/DisposableObject.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/JoltPhysicsSharp/Double3.cs
+++ b/src/JoltPhysicsSharp/Double3.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Diagnostics;

--- a/src/JoltPhysicsSharp/Foundation.cs
+++ b/src/JoltPhysicsSharp/Foundation.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/IndexedTriangle.cs
+++ b/src/JoltPhysicsSharp/IndexedTriangle.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/IndexedTriangleNoMaterial.cs
+++ b/src/JoltPhysicsSharp/IndexedTriangleNoMaterial.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/JobSystemThreadPool.cs
+++ b/src/JoltPhysicsSharp/JobSystemThreadPool.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/MonoPInvokeCallbackAttribute.cs
+++ b/src/JoltPhysicsSharp/MonoPInvokeCallbackAttribute.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 #if !NET6_0_OR_GREATER

--- a/src/JoltPhysicsSharp/MotionType.cs
+++ b/src/JoltPhysicsSharp/MotionType.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/NativeObject.cs
+++ b/src/JoltPhysicsSharp/NativeObject.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/ObjectLayer.cs
+++ b/src/JoltPhysicsSharp/ObjectLayer.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/ObjectLayerPairFilter.cs
+++ b/src/JoltPhysicsSharp/ObjectLayerPairFilter.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/JoltPhysicsSharp/ObjectVsBroadPhaseLayerFilter.cs
+++ b/src/JoltPhysicsSharp/ObjectVsBroadPhaseLayerFilter.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Runtime.CompilerServices;

--- a/src/JoltPhysicsSharp/PhysicsSystem.cs
+++ b/src/JoltPhysicsSharp/PhysicsSystem.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/PhysicsUpdateError.cs
+++ b/src/JoltPhysicsSharp/PhysicsUpdateError.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/Shape/BoxShape.cs
+++ b/src/JoltPhysicsSharp/Shape/BoxShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/CapsuleShape.cs
+++ b/src/JoltPhysicsSharp/Shape/CapsuleShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/CompoundShape.cs
+++ b/src/JoltPhysicsSharp/Shape/CompoundShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/ConvexHullShape.cs
+++ b/src/JoltPhysicsSharp/Shape/ConvexHullShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/ConvexShape.cs
+++ b/src/JoltPhysicsSharp/Shape/ConvexShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/CylinderShape.cs
+++ b/src/JoltPhysicsSharp/Shape/CylinderShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/HeightFieldShape.cs
+++ b/src/JoltPhysicsSharp/Shape/HeightFieldShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/MeshShape.cs
+++ b/src/JoltPhysicsSharp/Shape/MeshShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/MutableCompoundShape.cs
+++ b/src/JoltPhysicsSharp/Shape/MutableCompoundShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/Shape.cs
+++ b/src/JoltPhysicsSharp/Shape/Shape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/SphereShape.cs
+++ b/src/JoltPhysicsSharp/Shape/SphereShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/StaticCompoundShape.cs
+++ b/src/JoltPhysicsSharp/Shape/StaticCompoundShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Shape/TaperedCapsuleShape.cs
+++ b/src/JoltPhysicsSharp/Shape/TaperedCapsuleShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Shape/TriangleShape.cs
+++ b/src/JoltPhysicsSharp/Shape/TriangleShape.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/SubShapeIDPair.cs
+++ b/src/JoltPhysicsSharp/SubShapeIDPair.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;

--- a/src/JoltPhysicsSharp/TempAllocator.cs
+++ b/src/JoltPhysicsSharp/TempAllocator.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using static JoltPhysicsSharp.JoltApi;

--- a/src/JoltPhysicsSharp/Triangle.cs
+++ b/src/JoltPhysicsSharp/Triangle.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 using System.Numerics;

--- a/src/JoltPhysicsSharp/Unsafe.cs
+++ b/src/JoltPhysicsSharp/Unsafe.cs
@@ -1,0 +1,9 @@
+﻿// Copyright © Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+#if !NET
+namespace JoltPhysicsSharp;
+static class Unsafe
+{
+    public static unsafe ref T AsRef<T>(void* source) where T : unmanaged => ref *(T*)source;
+}
+#endif

--- a/src/JoltPhysicsSharp/Unsafe.cs
+++ b/src/JoltPhysicsSharp/Unsafe.cs
@@ -1,9 +1,0 @@
-﻿// Copyright © Amer Koleci and Contributors.
-// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
-#if !NET
-namespace JoltPhysicsSharp;
-static class Unsafe
-{
-    public static unsafe ref T AsRef<T>(void* source) where T : unmanaged => ref *(T*)source;
-}
-#endif

--- a/src/JoltPhysicsSharp/ValidateResult.cs
+++ b/src/JoltPhysicsSharp/ValidateResult.cs
@@ -1,4 +1,4 @@
-// Copyright © Amer Koleci and Contributors.
+// Copyright Â© Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
 namespace JoltPhysicsSharp;


### PR DESCRIPTION
struct Double3 used a lot of System.Runtime.CompilerServices.Unsafe things, so I cannot just simply delete the reference and replace the method now. I'll try to find other ways.