### PR TITLE
Fixes to raycasting bindings

### DIFF
--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -730,7 +730,7 @@ internal static unsafe partial class JoltApi
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern uint JPH_NarrowPhaseQuery_CastRay(nint system,
         in Vector3 origin, in Vector3 direction,
-        out RayCastResult hit,
+        ref RayCastResult hit,
         IntPtr broadPhaseLayerFilter,
         IntPtr objectLayerFilter,
         IntPtr bodyFilter);
@@ -738,7 +738,7 @@ internal static unsafe partial class JoltApi
     [DllImport(LibName, EntryPoint = nameof(JPH_NarrowPhaseQuery_CastRay), CallingConvention = CallingConvention.Cdecl)]
     public static extern uint JPH_NarrowPhaseQuery_CastRay_Double(nint system,
         in Double3 origin, in Vector3 direction,
-        out RayCastResult hit,
+        ref RayCastResult hit,
         IntPtr broadPhaseLayerFilter,
         IntPtr objectLayerFilter,
         IntPtr bodyFilter);

--- a/src/JoltPhysicsSharp/NarrowPhaseQuery.cs
+++ b/src/JoltPhysicsSharp/NarrowPhaseQuery.cs
@@ -25,31 +25,31 @@ public readonly struct NarrowPhaseQuery : IEquatable<NarrowPhaseQuery>
     /// <inheritdoc/>
     public override int GetHashCode() => Handle.GetHashCode();
 
-    public bool CastRay(in Vector3 origin, in Vector3 direction, out RayCastResult hit)
+    public bool CastRay(in Vector3 origin, in Vector3 direction, ref RayCastResult hit)
     {
         uint result = 0;
         if (DoublePrecision)
         {
-            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, new(origin), direction, out hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, new(origin), direction, ref hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
         }
         else
         {
-            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, out hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
         }
 
         return result == 1;
     }
 
-    public bool CastRay(in Double3 origin, in Vector3 direction, out RayCastResult hit)
+    public bool CastRay(in Double3 origin, in Vector3 direction, ref RayCastResult hit)
     {
         uint result = 0;
         if (DoublePrecision)
         {
-            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, origin, direction, out hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
         }
         else
         {
-            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, out hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
         }
 
         return result == 1;

--- a/src/JoltPhysicsSharp/RayCastResult.cs
+++ b/src/JoltPhysicsSharp/RayCastResult.cs
@@ -3,9 +3,25 @@
 
 namespace JoltPhysicsSharp;
 
-public readonly struct RayCastResult
+public struct RayCastResult
 {
-    public readonly BodyID BodyID;
-    public readonly float Fraction;
-    public readonly uint/*SubShapeID*/ subShapeID2;
+    /// <summary>
+    /// C Float Epsilon.
+    /// C# Float Epsilon has a different value than C Float Epsilon, which we need for default values
+    /// </summary>
+    const float CEpsilon = 1.192092896e-07F;
+
+    public BodyID BodyID;
+    public float Fraction;
+    public uint/*SubShapeID*/ subShapeID2;
+
+    /// <summary>
+    /// Default values for raycasting.
+    /// Required for raycasting successfully, as it expects these values to do it correctly.
+    /// </summary>
+    public static RayCastResult Default => new RayCastResult()
+    {
+        BodyID = BodyID.Invalid,
+        Fraction = 1.0f + CEpsilon,
+    };
 }

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -10,6 +10,7 @@
 #include <Jolt/Core/JobSystemThreadPool.h>
 #include <Jolt/Physics/PhysicsSettings.h>
 #include <Jolt/Physics/PhysicsSystem.h>
+#include <Jolt/Physics/Collision/CastResult.h>
 #include <Jolt/Physics/Collision/CollideShape.h>
 #include <Jolt/Physics/Collision/Shape/BoxShape.h>
 #include <Jolt/Physics/Collision/Shape/SphereShape.h>


### PR DESCRIPTION
# Changes

- Changed NarrowPhaseQuery Raycast bindings to pass the hit struct by ref instead of out due to required values
- Added missing JoltC CastResult header which resulted in incomplete type reinterpret cast

# Background

To properly perform raycasts, it's necessary to set some values that Jolt expects. These include:

- Invalid Body ID
- Fraction equal to 1 + float epsilon

Otherwise, I was having broken behaviour:
- It would always return 1
- It would never change my hit values

Additionally, C#'s float epsilon is different than C/C++'s float epsilon, so I had to embed the value in the struct (but if you have a better place to put it, I'm happy to change that!)

To properly support this, the changes I made are as follows:

- Pass the struct by ref rather than out, since it is used for both input and output
- Change the struct to no longer be readonly, since it needs to be modified
- Add a default values static property to `RaycastResult`

After these changes, it seems to work for me.