### PR TITLE
Add C/C# custom assert handler support

### DIFF
--- a/src/JoltPhysicsSharp/Foundation.cs
+++ b/src/JoltPhysicsSharp/Foundation.cs
@@ -1,6 +1,7 @@
 // Copyright © Amer Koleci and Contributors.
 // Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
 
+using System.Runtime.InteropServices;
 using static JoltPhysicsSharp.JoltApi;
 
 namespace JoltPhysicsSharp;
@@ -37,6 +38,8 @@ public static class Foundation
     /// </summary>
     public const int MaxPhysicsBarriers = 8;
 
+    public delegate bool AssertFailedImpl(string inExpression, string inMessage, string inFile, uint inLine);
+
     public static bool Init(bool doublePrecision = false)
     {
         JoltApi.DoublePrecision = doublePrecision;
@@ -48,4 +51,6 @@ public static class Foundation
     }
 
     public static void Shutdown() => JPH_Shutdown();
+
+    public static void SetAssertFailureHandler(AssertFailedImpl impl) => JPH_SetAssertFailureHandler(Marshal.GetFunctionPointerForDelegate(impl));
 }

--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -149,6 +149,9 @@ internal static unsafe partial class JoltApi
     public static extern void JPH_Shutdown();
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_SetAssertFailureHandler(IntPtr handler);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern IntPtr JPH_TempAllocatorMalloc_Create();
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -210,8 +210,8 @@ JPH_Bool32 JPH_Init(void)
     JPH::Trace = TraceImpl;
     JPH_IF_ENABLE_ASSERTS(JPH::AssertFailed = AssertFailedImpl;)
 
-        // Create a factory
-        JPH::Factory::sInstance = new JPH::Factory();
+    // Create a factory
+    JPH::Factory::sInstance = new JPH::Factory();
 
     // Register all Jolt physics types
     JPH::RegisterTypes();
@@ -227,6 +227,13 @@ void JPH_Shutdown(void)
     // Destroy the factory
     delete JPH::Factory::sInstance;
     JPH::Factory::sInstance = nullptr;
+}
+
+void JPH_SetAssertFailureHandler(bool (*handler)(const char* inExpression, const char* inMessage, const char* inFile, uint32_t inLine))
+{
+#ifdef JPH_ENABLE_ASSERTS
+    JPH_IF_ENABLE_ASSERTS(JPH::AssertFailed = handler;)
+#endif
 }
 
 JPH_TempAllocator* JPH_TempAllocatorMalloc_Create()

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -39,6 +39,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 typedef uint32_t JPH_Bool32;
 typedef uint32_t JPH_BodyID;
@@ -238,6 +239,7 @@ typedef struct JPH_BodyLockWrite
 
 JPH_CAPI JPH_Bool32 JPH_Init(void);
 JPH_CAPI void JPH_Shutdown(void);
+JPH_CAPI void JPH_SetAssertFailureHandler(bool (*handler)(const char* inExpression, const char* inMessage, const char* inFile, unsigned int inLine));
 
 /* JPH_TempAllocator */
 JPH_CAPI JPH_TempAllocator* JPH_TempAllocatorMalloc_Create();


### PR DESCRIPTION
- Adds a method for JoltC/JoltPhysicsSharp to set a specific assert failure handler

# Background

Due to a failing test with an assert, I needed to add this, since Visual Studio 2022 doesn't show stdout on test explorer.

Please let me know if you'd like me to add support for custom traces as well (since there's a function for that too, but I'm not sure if it's worth adding that too)