### PR TITLE
Add CastRay filter classes

### DIFF
--- a/src/JoltPhysicsSharp/BodyFilter.cs
+++ b/src/JoltPhysicsSharp/BodyFilter.cs
@@ -1,0 +1,75 @@
+﻿// Copyright © Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using static JoltPhysicsSharp.JoltApi;
+
+namespace JoltPhysicsSharp;
+
+public abstract class BodyFilter : NativeObject
+{
+    private static readonly Dictionary<IntPtr, BodyFilter> s_listeners = new();
+    private static readonly JPH_BodyFilter_Procs s_bodyFilter_Procs;
+
+    static unsafe BodyFilter()
+    {
+        s_bodyFilter_Procs = new JPH_BodyFilter_Procs
+        {
+#if NET6_0_OR_GREATER
+            ShouldCollide = &ShouldCollideCallback,
+            ShouldCollideLocked = &ShouldCollideLockedCallback,
+#else
+            ShouldCollide = ShouldCollideCallback,
+            ShouldCollideLocked = ShouldCollideLockedCallback,
+#endif
+        };
+        JPH_BodyFilter_SetProcs(s_bodyFilter_Procs);
+    }
+
+    public BodyFilter()
+        : base(JPH_BodyFilter_Create())
+    {
+        s_listeners.Add(Handle, this);
+    }
+
+    /// <summary>
+    /// Finalizes an instance of the <see cref="BodyFilter" /> class.
+    /// </summary>
+    ~BodyFilter() => Dispose(isDisposing: false);
+
+    protected override void Dispose(bool isDisposing)
+    {
+        if (isDisposing)
+        {
+            s_listeners.Remove(Handle);
+
+            JPH_BodyFilter_Destroy(Handle);
+        }
+    }
+
+    protected abstract bool ShouldCollide(BodyID bodyID);
+    protected abstract bool ShouldCollideLocked(Body body);
+    
+#if NET6_0_OR_GREATER
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+#else
+    [MonoPInvokeCallback(typeof(BodyFilterShouldCollideDelegate))]
+#endif
+    private static uint ShouldCollideCallback(IntPtr listenerPtr, BodyID bodyID)
+    {
+        BodyFilter listener = s_listeners[listenerPtr];
+        return (uint)(listener.ShouldCollide(bodyID) ? 1 : 0);
+    }
+
+#if NET6_0_OR_GREATER
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+#else
+    [MonoPInvokeCallback(typeof(BodyFilterShouldCollideLockedDelegate))]
+#endif
+    private static uint ShouldCollideLockedCallback(IntPtr listenerPtr, IntPtr body)
+    {
+        BodyFilter listener = s_listeners[listenerPtr];
+        return (uint)(listener.ShouldCollideLocked(body) ? 1 : 0);
+    }
+}

--- a/src/JoltPhysicsSharp/BroadPhaseLayerFilter.cs
+++ b/src/JoltPhysicsSharp/BroadPhaseLayerFilter.cs
@@ -1,0 +1,61 @@
+﻿// Copyright © Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using static JoltPhysicsSharp.JoltApi;
+
+namespace JoltPhysicsSharp;
+
+public abstract class BroadPhaseLayerFilter : NativeObject
+{
+    private static readonly Dictionary<IntPtr, BroadPhaseLayerFilter> s_listeners = new();
+    private static readonly JPH_BroadPhaseLayerFilter_Procs s_broadPhaseLayerFilter_Procs;
+
+    static unsafe BroadPhaseLayerFilter()
+    {
+        s_broadPhaseLayerFilter_Procs = new JPH_BroadPhaseLayerFilter_Procs
+        {
+#if NET6_0_OR_GREATER
+            ShouldCollide = &ShouldCollideCallback,
+#else
+            ShouldCollide = ShouldCollideCallback,
+#endif
+        };
+        JPH_BroadPhaseLayerFilter_SetProcs(s_broadPhaseLayerFilter_Procs);
+    }
+
+    public BroadPhaseLayerFilter()
+        : base(JPH_BroadPhaseLayerFilter_Create())
+    {
+        s_listeners.Add(Handle, this);
+    }
+
+    /// <summary>
+    /// Finalizes an instance of the <see cref="BodyFilter" /> class.
+    /// </summary>
+    ~BroadPhaseLayerFilter() => Dispose(isDisposing: false);
+
+    protected override void Dispose(bool isDisposing)
+    {
+        if (isDisposing)
+        {
+            s_listeners.Remove(Handle);
+
+            JPH_BroadPhaseLayerFilter_Destroy(Handle);
+        }
+    }
+
+    protected abstract bool ShouldCollide(BroadPhaseLayer layer);
+
+#if NET6_0_OR_GREATER
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+#else
+    [MonoPInvokeCallback(typeof(BroadPhaseLayerFilterShouldCollideDelegate))]
+#endif
+    private static uint ShouldCollideCallback(IntPtr listenerPtr, BroadPhaseLayer layer)
+    {
+        BroadPhaseLayerFilter listener = s_listeners[listenerPtr];
+        return (uint)(listener.ShouldCollide(layer) ? 1 : 0);
+    }
+}

--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -316,6 +316,100 @@ internal static unsafe partial class JoltApi
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern void JPH_ObjectLayerPairFilter_Destroy(nint handle);
 
+    //  BroadPhaseLayerFilter
+#if NET6_0_OR_GREATER
+    public struct JPH_BroadPhaseLayerFilter_Procs
+    {
+        public delegate* unmanaged[Cdecl]<IntPtr, BroadPhaseLayer, uint> ShouldCollide;
+    }
+#else
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate uint BroadPhaseLayerFilterShouldCollideDelegate(IntPtr @this, BroadPhaseLayer layer);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct JPH_BroadPhaseLayerFilter_Procs : IEquatable<JPH_BroadPhaseLayerFilter_Procs>
+    {
+        public BroadPhaseLayerFilterShouldCollideDelegate ShouldCollide;
+
+        public readonly bool Equals(JPH_BroadPhaseLayerFilter_Procs obj)
+        {
+            return
+                ShouldCollide == obj.ShouldCollide;
+        }
+
+        public readonly override bool Equals(object obj) => obj is JPH_BroadPhaseLayerFilter_Procs f && Equals(f);
+
+        public static bool operator ==(JPH_BroadPhaseLayerFilter_Procs left, JPH_BroadPhaseLayerFilter_Procs right) =>
+            left.Equals(right);
+
+        public static bool operator !=(JPH_BroadPhaseLayerFilter_Procs left, JPH_BroadPhaseLayerFilter_Procs right) =>
+            !left.Equals(right);
+
+        public override readonly int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(ShouldCollide);
+            return hash.ToHashCode();
+        }
+    }
+#endif
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_BroadPhaseLayerFilter_SetProcs(JPH_BroadPhaseLayerFilter_Procs procs);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern nint JPH_BroadPhaseLayerFilter_Create();
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_BroadPhaseLayerFilter_Destroy(nint handle);
+
+    //  ObjectLayerFilter
+#if NET6_0_OR_GREATER
+    public struct JPH_ObjectLayerFilter_Procs
+    {
+        public delegate* unmanaged[Cdecl]<IntPtr, ObjectLayer, uint> ShouldCollide;
+    }
+#else
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate uint ObjectLayerFilterShouldCollideDelegate(IntPtr @this, ObjectLayer layer);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct JPH_ObjectLayerFilter_Procs : IEquatable<JPH_ObjectLayerFilter_Procs>
+    {
+        public ObjectLayerFilterShouldCollideDelegate ShouldCollide;
+
+        public readonly bool Equals(JPH_ObjectLayerFilter_Procs obj)
+        {
+            return
+                ShouldCollide == obj.ShouldCollide;
+        }
+
+        public readonly override bool Equals(object obj) => obj is JPH_ObjectLayerFilter_Procs f && Equals(f);
+
+        public static bool operator ==(JPH_ObjectLayerFilter_Procs left, JPH_ObjectLayerFilter_Procs right) =>
+            left.Equals(right);
+
+        public static bool operator !=(JPH_ObjectLayerFilter_Procs left, JPH_ObjectLayerFilter_Procs right) =>
+            !left.Equals(right);
+
+        public override readonly int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(ShouldCollide);
+            return hash.ToHashCode();
+        }
+    }
+#endif
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_ObjectLayerFilter_SetProcs(JPH_ObjectLayerFilter_Procs procs);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern nint JPH_ObjectLayerFilter_Create();
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_ObjectLayerFilter_Destroy(nint handle);
+
     //  BodyFilter
 #if NET6_0_OR_GREATER
     public struct JPH_BodyFilter_Procs

--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -316,6 +316,60 @@ internal static unsafe partial class JoltApi
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern void JPH_ObjectLayerPairFilter_Destroy(nint handle);
 
+    //  BodyFilter
+#if NET6_0_OR_GREATER
+    public struct JPH_BodyFilter_Procs
+    {
+        public delegate* unmanaged[Cdecl]<IntPtr, BodyID, uint> ShouldCollide;
+        public delegate* unmanaged[Cdecl]<IntPtr, IntPtr, uint> ShouldCollideLocked;
+    }
+#else
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate uint BodyFilterShouldCollideDelegate(IntPtr @this, BodyID bodyID);
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate uint BodyFilterShouldCollideLockedDelegate(IntPtr @this, IntPtr body);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct JPH_BodyFilter_Procs : IEquatable<JPH_BodyFilter_Procs>
+    {
+        public BodyFilterShouldCollideDelegate ShouldCollide;
+        public BodyFilterShouldCollideLockedDelegate ShouldCollideLocked;
+
+        public readonly bool Equals(JPH_BodyFilter_Procs obj)
+        {
+            return
+                ShouldCollide == obj.ShouldCollide &&
+                ShouldCollideLocked == obj.ShouldCollideLocked;
+        }
+
+        public readonly override bool Equals(object obj) => obj is JPH_BodyFilter_Procs f && Equals(f);
+
+        public static bool operator ==(JPH_BodyFilter_Procs left, JPH_BodyFilter_Procs right) =>
+            left.Equals(right);
+
+        public static bool operator !=(JPH_BodyFilter_Procs left, JPH_BodyFilter_Procs right) =>
+            !left.Equals(right);
+
+        public override readonly int GetHashCode()
+        {
+            var hash = new HashCode();
+            hash.Add(ShouldCollide);
+            hash.Add(ShouldCollideLocked);
+            return hash.ToHashCode();
+        }
+    }
+#endif
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_BodyFilter_SetProcs(JPH_BodyFilter_Procs procs);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern nint JPH_BodyFilter_Create();
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_BodyFilter_Destroy(nint handle);
+
     /* ShapeSettings */
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern void JPH_ShapeSettings_Destroy(nint shape);

--- a/src/JoltPhysicsSharp/NarrowPhaseQuery.cs
+++ b/src/JoltPhysicsSharp/NarrowPhaseQuery.cs
@@ -25,31 +25,31 @@ public readonly struct NarrowPhaseQuery : IEquatable<NarrowPhaseQuery>
     /// <inheritdoc/>
     public override int GetHashCode() => Handle.GetHashCode();
 
-    public bool CastRay(in Vector3 origin, in Vector3 direction, ref RayCastResult hit)
+    public bool CastRay(in Vector3 origin, in Vector3 direction, ref RayCastResult hit, BodyFilter bodyFilter)
     {
         uint result = 0;
         if (DoublePrecision)
         {
-            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, new(origin), direction, ref hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, new(origin), direction, ref hit, IntPtr.Zero, IntPtr.Zero, bodyFilter.Handle);
         }
         else
         {
-            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, bodyFilter.Handle);
         }
 
         return result == 1;
     }
 
-    public bool CastRay(in Double3 origin, in Vector3 direction, ref RayCastResult hit)
+    public bool CastRay(in Double3 origin, in Vector3 direction, ref RayCastResult hit, BodyFilter bodyFilter)
     {
         uint result = 0;
         if (DoublePrecision)
         {
-            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, bodyFilter.Handle);
         }
         else
         {
-            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
+            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, bodyFilter.Handle);
         }
 
         return result == 1;

--- a/src/JoltPhysicsSharp/NarrowPhaseQuery.cs
+++ b/src/JoltPhysicsSharp/NarrowPhaseQuery.cs
@@ -25,31 +25,33 @@ public readonly struct NarrowPhaseQuery : IEquatable<NarrowPhaseQuery>
     /// <inheritdoc/>
     public override int GetHashCode() => Handle.GetHashCode();
 
-    public bool CastRay(in Vector3 origin, in Vector3 direction, ref RayCastResult hit, BodyFilter bodyFilter)
+    public bool CastRay(in Vector3 origin, in Vector3 direction, ref RayCastResult hit, BroadPhaseLayerFilter broadPhaseFilter,
+        ObjectLayerFilter objectLayerFilter, BodyFilter bodyFilter)
     {
-        uint result = 0;
+        uint result;
         if (DoublePrecision)
         {
-            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, new(origin), direction, ref hit, IntPtr.Zero, IntPtr.Zero, bodyFilter.Handle);
+            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, new(origin), direction, ref hit, broadPhaseFilter.Handle, objectLayerFilter.Handle, bodyFilter.Handle);
         }
         else
         {
-            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, bodyFilter.Handle);
+            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, broadPhaseFilter.Handle, objectLayerFilter.Handle, bodyFilter.Handle);
         }
 
         return result == 1;
     }
 
-    public bool CastRay(in Double3 origin, in Vector3 direction, ref RayCastResult hit, BodyFilter bodyFilter)
+    public bool CastRay(in Double3 origin, in Vector3 direction, ref RayCastResult hit, BroadPhaseLayerFilter broadPhaseFilter,
+        ObjectLayerFilter objectLayerFilter, BodyFilter bodyFilter)
     {
-        uint result = 0;
+        uint result;
         if (DoublePrecision)
         {
-            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, bodyFilter.Handle);
+            result = JPH_NarrowPhaseQuery_CastRay_Double(Handle, origin, direction, ref hit, broadPhaseFilter.Handle, objectLayerFilter.Handle, bodyFilter.Handle);
         }
         else
         {
-            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, IntPtr.Zero, IntPtr.Zero, bodyFilter.Handle);
+            result = JPH_NarrowPhaseQuery_CastRay(Handle, origin, direction, ref hit, broadPhaseFilter.Handle, objectLayerFilter.Handle, bodyFilter.Handle);
         }
 
         return result == 1;

--- a/src/JoltPhysicsSharp/ObjectLayerFilter.cs
+++ b/src/JoltPhysicsSharp/ObjectLayerFilter.cs
@@ -1,0 +1,61 @@
+﻿// Copyright © Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using static JoltPhysicsSharp.JoltApi;
+
+namespace JoltPhysicsSharp;
+
+public abstract class ObjectLayerFilter : NativeObject
+{
+    private static readonly Dictionary<IntPtr, ObjectLayerFilter> s_listeners = new();
+    private static readonly JPH_ObjectLayerFilter_Procs s_objectLayerFilter_Procs;
+
+    static unsafe ObjectLayerFilter()
+    {
+        s_objectLayerFilter_Procs = new JPH_ObjectLayerFilter_Procs
+        {
+#if NET6_0_OR_GREATER
+            ShouldCollide = &ShouldCollideCallback,
+#else
+            ShouldCollide = ShouldCollideCallback,
+#endif
+        };
+        JPH_ObjectLayerFilter_SetProcs(s_objectLayerFilter_Procs);
+    }
+
+    public ObjectLayerFilter()
+        : base(JPH_ObjectLayerFilter_Create())
+    {
+        s_listeners.Add(Handle, this);
+    }
+
+    /// <summary>
+    /// Finalizes an instance of the <see cref="BodyFilter" /> class.
+    /// </summary>
+    ~ObjectLayerFilter() => Dispose(isDisposing: false);
+
+    protected override void Dispose(bool isDisposing)
+    {
+        if (isDisposing)
+        {
+            s_listeners.Remove(Handle);
+
+            JPH_ObjectLayerFilter_Destroy(Handle);
+        }
+    }
+
+    protected abstract bool ShouldCollide(ObjectLayer layer);
+
+#if NET6_0_OR_GREATER
+    [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvCdecl) })]
+#else
+    [MonoPInvokeCallback(typeof(ObjectLayerFilterShouldCollideDelegate))]
+#endif
+    private static uint ShouldCollideCallback(IntPtr listenerPtr, ObjectLayer layer)
+    {
+        ObjectLayerFilter listener = s_listeners[listenerPtr];
+        return (uint)(listener.ShouldCollide(layer) ? 1 : 0);
+    }
+}

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -415,6 +415,88 @@ void JPH_ObjectLayerPairFilter_Destroy(JPH_ObjectLayerPairFilter* filter)
     }
 }
 
+/* JPH_BroadPhaseLayerFilter */
+static JPH_BroadPhaseLayerFilter_Procs g_BroadPhaseLayerFilter_Procs;
+
+class ManagedBroadPhaseLayerFilter final : public JPH::BroadPhaseLayerFilter
+{
+public:
+    ManagedBroadPhaseLayerFilter() = default;
+
+    ManagedBroadPhaseLayerFilter(const ManagedBroadPhaseLayerFilter&) = delete;
+    ManagedBroadPhaseLayerFilter(const ManagedBroadPhaseLayerFilter&&) = delete;
+    ManagedBroadPhaseLayerFilter& operator=(const ManagedBroadPhaseLayerFilter&) = delete;
+    ManagedBroadPhaseLayerFilter& operator=(const ManagedBroadPhaseLayerFilter&&) = delete;
+
+    bool ShouldCollide(BroadPhaseLayer inLayer) const override
+    {
+        return g_BroadPhaseLayerFilter_Procs.ShouldCollide(
+            reinterpret_cast<const JPH_BroadPhaseLayerFilter*>(this),
+            static_cast<JPH_BroadPhaseLayer>(inLayer)
+        ) == 1;
+    }
+};
+
+void JPH_BroadPhaseLayerFilter_SetProcs(JPH_BroadPhaseLayerFilter_Procs procs)
+{
+    g_BroadPhaseLayerFilter_Procs = procs;
+}
+
+JPH_BroadPhaseLayerFilter* JPH_BroadPhaseLayerFilter_Create()
+{
+    auto filter = new ManagedBroadPhaseLayerFilter();
+    return reinterpret_cast<JPH_BroadPhaseLayerFilter*>(filter);
+}
+
+void JPH_BroadPhaseLayerFilter_Destroy(JPH_BroadPhaseLayerFilter* filter)
+{
+    if (filter)
+    {
+        delete reinterpret_cast<ManagedBroadPhaseLayerFilter*>(filter);
+    }
+}
+
+/* JPH_ObjectLayerFilter */
+static JPH_ObjectLayerFilter_Procs g_ObjectLayerFilter_Procs;
+
+class ManagedObjectLayerFilter final : public JPH::ObjectLayerFilter
+{
+public:
+    ManagedObjectLayerFilter() = default;
+
+    ManagedObjectLayerFilter(const ManagedObjectLayerFilter&) = delete;
+    ManagedObjectLayerFilter(const ManagedObjectLayerFilter&&) = delete;
+    ManagedObjectLayerFilter& operator=(const ManagedObjectLayerFilter&) = delete;
+    ManagedObjectLayerFilter& operator=(const ManagedObjectLayerFilter&&) = delete;
+
+    bool ShouldCollide(ObjectLayer inLayer) const override
+    {
+        return g_ObjectLayerFilter_Procs.ShouldCollide(
+            reinterpret_cast<const JPH_ObjectLayerFilter*>(this),
+            static_cast<JPH_ObjectLayer>(inLayer)
+        ) == 1;
+    }
+};
+
+void JPH_ObjectLayerFilter_SetProcs(JPH_ObjectLayerFilter_Procs procs)
+{
+    g_ObjectLayerFilter_Procs = procs;
+}
+
+JPH_ObjectLayerFilter* JPH_ObjectLayerFilter_Create()
+{
+    auto filter = new ManagedObjectLayerFilter();
+    return reinterpret_cast<JPH_ObjectLayerFilter*>(filter);
+}
+
+void JPH_ObjectLayerFilter_Destroy(JPH_ObjectLayerFilter* filter)
+{
+    if (filter)
+    {
+        delete reinterpret_cast<ManagedObjectLayerFilter*>(filter);
+    }
+}
+
 /* JPH_BodyFilter */
 static JPH_BodyFilter_Procs g_BodyFilter_Procs;
 

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -178,6 +178,8 @@ typedef struct JPH_JobSystemThreadPool              JPH_JobSystemThreadPool;
 typedef struct JPH_BroadPhaseLayerInterface         JPH_BroadPhaseLayerInterface;
 typedef struct JPH_ObjectVsBroadPhaseLayerFilter    JPH_ObjectVsBroadPhaseLayerFilter;
 typedef struct JPH_ObjectLayerPairFilter            JPH_ObjectLayerPairFilter;
+typedef struct JPH_BroadPhaseLayerFilter            JPH_BroadPhaseLayerFilter;
+typedef struct JPH_ObjectLayerFilter                JPH_ObjectLayerFilter;
 typedef struct JPH_BodyFilter                       JPH_BodyFilter;
 
 typedef struct JPH_PhysicsSystem                    JPH_PhysicsSystem;
@@ -538,6 +540,24 @@ typedef struct JPH_ObjectLayerPairFilter_Procs {
 JPH_CAPI void JPH_ObjectLayerPairFilter_SetProcs(JPH_ObjectLayerPairFilter_Procs procs);
 JPH_CAPI JPH_ObjectLayerPairFilter* JPH_ObjectLayerPairFilter_Create();
 JPH_CAPI void JPH_ObjectLayerPairFilter_Destroy(JPH_ObjectLayerPairFilter* filter);
+
+/* JPH_BroadPhaseLayerFilter_Procs */
+typedef struct JPH_BroadPhaseLayerFilter_Procs {
+    JPH_Bool32(JPH_API_CALL* ShouldCollide)(const JPH_BroadPhaseLayerFilter* filter, JPH_BroadPhaseLayer layer);
+} JPH_BroadPhaseLayerFilter_Procs;
+
+JPH_CAPI void JPH_BroadPhaseLayerFilter_SetProcs(JPH_BroadPhaseLayerFilter_Procs procs);
+JPH_CAPI JPH_BroadPhaseLayerFilter* JPH_BroadPhaseLayerFilter_Create();
+JPH_CAPI void JPH_BroadPhaseLayerFilter_Destroy(JPH_BroadPhaseLayerFilter* filter);
+
+/* JPH_ObjectLayerFilter */
+typedef struct JPH_ObjectLayerFilter_Procs {
+    JPH_Bool32(JPH_API_CALL* ShouldCollide)(const JPH_ObjectLayerFilter *filter, JPH_ObjectLayer layer);
+} JPH_ObjectLayherFilter_Procs;
+
+JPH_CAPI void JPH_ObjectLayerFilter_SetProcs(JPH_ObjectLayerFilter_Procs procs);
+JPH_CAPI JPH_ObjectLayerFilter* JPH_ObjectLayerFilter_Create();
+JPH_CAPI void JPH_ObjectLayerFilter_Destroy(JPH_ObjectLayerFilter* filter);
 
 /* JPH_BodyFilter */
 typedef struct JPH_BodyFilter_Procs {

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -178,6 +178,7 @@ typedef struct JPH_JobSystemThreadPool              JPH_JobSystemThreadPool;
 typedef struct JPH_BroadPhaseLayerInterface         JPH_BroadPhaseLayerInterface;
 typedef struct JPH_ObjectVsBroadPhaseLayerFilter    JPH_ObjectVsBroadPhaseLayerFilter;
 typedef struct JPH_ObjectLayerPairFilter            JPH_ObjectLayerPairFilter;
+typedef struct JPH_BodyFilter                       JPH_BodyFilter;
 
 typedef struct JPH_PhysicsSystem                    JPH_PhysicsSystem;
 
@@ -537,6 +538,16 @@ typedef struct JPH_ObjectLayerPairFilter_Procs {
 JPH_CAPI void JPH_ObjectLayerPairFilter_SetProcs(JPH_ObjectLayerPairFilter_Procs procs);
 JPH_CAPI JPH_ObjectLayerPairFilter* JPH_ObjectLayerPairFilter_Create();
 JPH_CAPI void JPH_ObjectLayerPairFilter_Destroy(JPH_ObjectLayerPairFilter* filter);
+
+/* JPH_BodyFilter */
+typedef struct JPH_BodyFilter_Procs {
+    JPH_Bool32(JPH_API_CALL* ShouldCollide)(const JPH_BodyFilter* filter, JPH_BodyID bodyID);
+    JPH_Bool32(JPH_API_CALL* ShouldCollideLocked)(const JPH_BodyFilter* filter, const JPH_Body *bodyID);
+} JPH_BodyFilter_Procs;
+
+JPH_CAPI void JPH_BodyFilter_SetProcs(JPH_BodyFilter_Procs procs);
+JPH_CAPI JPH_BodyFilter* JPH_BodyFilter_Create();
+JPH_CAPI void JPH_BodyFilter_Destroy(JPH_BodyFilter* filter);
 
 /* Contact listener */
 typedef struct JPH_ContactListener_Procs {


### PR DESCRIPTION
# Changes

- Adds the `BroadPhaseLayerFilter`, `ObjectLayerFilter`, and `BodyFilter` classes to the C# bindings
- Adds parameters for each on NarrowPhase's `CastRay` method

# Background

This is needed to support filtering raycast hits.