### PR TITLE
change JPH_NarrowPhaseQuery_CastRay include body id's

### DIFF
--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -2510,8 +2510,8 @@ JPH_Bool32 JPH_NarrowPhaseQuery_CastRay(const JPH_NarrowPhaseQuery* query,
     );
     if (collector.HadHit())
         hit->fraction = collector.mHit.mFraction;
-		hit->bodyID = collector.mHit.mBodyID;
-		hit->subShapeID2 = collector.mHit.mSubShapeID2;
+		hit->bodyID = collector.mHit.mBodyID.GetIndexAndSequenceNumber();
+		hit->subShapeID2 = collector.mHit.mSubShapeID2.GetValue();
     return collector.HadHit();
 }
 

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -2510,8 +2510,8 @@ JPH_Bool32 JPH_NarrowPhaseQuery_CastRay(const JPH_NarrowPhaseQuery* query,
     );
     if (collector.HadHit())
         hit->fraction = collector.mHit.mFraction;
-		hit->bodyID = collector.mHit.mBodyID
-		hit->subShapeID2 = collector.mHit.mSubShapeID2
+		hit->bodyID = collector.mHit.mBodyID;
+		hit->subShapeID2 = collector.mHit.mSubShapeID2;
     return collector.HadHit();
 }
 

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -2510,6 +2510,8 @@ JPH_Bool32 JPH_NarrowPhaseQuery_CastRay(const JPH_NarrowPhaseQuery* query,
     );
     if (collector.HadHit())
         hit->fraction = collector.mHit.mFraction;
+		hit->bodyID = collector.mHit.mBodyID
+		hit->subShapeID2 = collector.mHit.mSubShapeID2
     return collector.HadHit();
 }
 


### PR DESCRIPTION
I'm using this binding for engine and i have no way to select objects with raycasts without it returning the ID.