### PR TITLE
Add bindings for StateRecorder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,10 +118,10 @@ if (MSVC)
 	# Set compiler flag for disabling RTTI
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR-")
 
-	if ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM")
+	# if ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "ARM")
 		# On ARM the exception handling flag is missing which causes warnings
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
-	endif()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+	# endif()
 
 	# Set compiler flags for various configurations
 	set(CMAKE_CXX_FLAGS_DEBUG "/GS /Od /Ob0 /RTC1")

--- a/src/JoltPhysicsSharp/Character/CharacterBase.cs
+++ b/src/JoltPhysicsSharp/Character/CharacterBase.cs
@@ -62,4 +62,14 @@ public abstract class CharacterBase : NativeObject
     {
         return JPH_CharacterBase_GetGroundSubShapeId(Handle);
     }
+
+    public void SaveState(StateRecorder recorder)
+    {
+        JPH_CharacterBase_SaveState(Handle, recorder.Handle);
+    }
+
+    public void RestoreState(StateRecorder recorder)
+    {
+        JPH_CharacterBase_RestoreState(Handle, recorder.Handle);
+    }
 }

--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -606,6 +606,12 @@ internal static unsafe partial class JoltApi
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern void JPH_PhysicsSystem_RemoveConstraints(IntPtr handle, IntPtr* constraints, uint count);
 
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_PhysicsSystem_SaveState(IntPtr handle, IntPtr recorder, StateRecorderState state);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_PhysicsSystem_RestoreState(IntPtr handle, IntPtr recorder);
+
 
     /* BodyInterface */
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
@@ -1060,6 +1066,12 @@ internal static unsafe partial class JoltApi
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern uint JPH_CharacterBase_GetGroundSubShapeId(IntPtr handle);
 
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_CharacterBase_SaveState(IntPtr handle, IntPtr recorder);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_CharacterBase_RestoreState(IntPtr handle, IntPtr recorder);
+
     /* CharacterVirtualSettings */
     [LibraryImport(LibName)]
     public static partial nint JPH_CharacterVirtualSettings_Create();
@@ -1088,4 +1100,41 @@ internal static unsafe partial class JoltApi
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern void JPH_CharacterVirtual_ExtendedUpdate(nint handle, float deltaTime, ExtendedUpdateSettings* settings, ushort layer, nint physicsSytem);
+
+    /* StateRecorder */
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern nint JPH_StateRecorder_Create();
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_StateRecorder_Destroy(nint handle);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern nint JPH_StateRecorder_SetValidating(nint handle, Bool32 validating);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern Bool32 JPH_StateRecorder_IsValidating(nint handle);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_StateRecorder_Rewind(nint handle);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_StateRecorder_Clear(nint handle);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern Bool32 JPH_StateRecorder_IsEOF(nint handle);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern Bool32 JPH_StateRecorder_IsFailed(nint handle);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern Bool32 JPH_StateRecorder_IsEqual(nint handle, nint other);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_StateRecorder_WriteBytes(nint handle, nint data, ulong size);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern void JPH_StateRecorder_ReadBytes(nint handle, nint data, ulong size);
+
+    [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
+    public static extern ulong JPH_StateRecorder_GetSize(nint handle);
 }

--- a/src/JoltPhysicsSharp/PhysicsSystem.cs
+++ b/src/JoltPhysicsSharp/PhysicsSystem.cs
@@ -230,6 +230,16 @@ public sealed class PhysicsSystem : NativeObject
         }
     }
 
+    public void SaveState(StateRecorder recorder, StateRecorderState state)
+    {
+        JPH_PhysicsSystem_SaveState(Handle, recorder.Handle, state);
+    }
+
+    public void RestoreState(StateRecorder recorder)
+    {
+        JPH_PhysicsSystem_RestoreState(Handle, recorder.Handle);
+    }
+
     #region ContactListener
     [UnmanagedCallersOnly]
     private static unsafe uint OnContactValidateCallback(IntPtr listenerPtr, IntPtr body1, IntPtr body2, Double3* baseOffset, IntPtr collisionResult)

--- a/src/JoltPhysicsSharp/StateRecorder.cs
+++ b/src/JoltPhysicsSharp/StateRecorder.cs
@@ -1,0 +1,81 @@
+// Copyright (c) Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+using static JoltPhysicsSharp.JoltApi;
+
+namespace JoltPhysicsSharp;
+
+public enum StateRecorderState
+{
+    None = 0,
+    Global = 1,
+	Bodies = 2,
+	Contacts = 4,
+	Constraints = 8,
+	All = None | Global | Bodies | Contacts | Constraints
+}
+
+public sealed class StateRecorder : NativeObject
+{
+	public StateRecorder()
+        : base(JPH_StateRecorder_Create())
+    {
+
+    }
+
+	~StateRecorder() => Dispose(isDisposing: false);
+
+    protected override void Dispose(bool isDisposing)
+    {
+        if (isDisposing)
+        {
+            JPH_StateRecorder_Destroy(Handle);
+        }
+    }
+
+	public bool Validating
+    {
+        get => JPH_StateRecorder_IsValidating(Handle);
+        set => JPH_StateRecorder_SetValidating(Handle, value);
+    }
+
+	public void Rewind()
+	{
+		JPH_StateRecorder_Rewind(Handle);
+	}
+
+	public void Clear()
+	{
+		JPH_StateRecorder_Clear(Handle);
+	}
+
+	public bool IsEOF()
+	{
+		return JPH_StateRecorder_IsEOF(Handle);
+	}
+
+	public bool IsFailed()
+	{
+		return JPH_StateRecorder_IsFailed(Handle);
+	}
+
+	public bool IsEqual(StateRecorder other)
+	{
+		return JPH_StateRecorder_IsEqual(Handle, other.Handle);
+	}
+
+	public void WriteBytes(nint data, ulong size)
+	{
+		JPH_StateRecorder_WriteBytes(Handle, data, size);
+	}
+
+	public void ReadBytes(nint data, ulong size)
+	{
+		JPH_StateRecorder_ReadBytes(Handle, data, size);
+	}
+
+	public ulong GetSize()
+	{
+		return JPH_StateRecorder_GetSize(Handle);
+	}
+}

--- a/src/joltc/CMakeLists.txt
+++ b/src/joltc/CMakeLists.txt
@@ -22,6 +22,7 @@ set_target_properties(${TARGET_NAME} PROPERTIES
 
 if (MSVC)
     target_compile_options(${TARGET_NAME} PRIVATE /Wall /WX)
+    target_compile_options(${TARGET_NAME} PRIVATE /wd4710)
 else()
     target_compile_options(${TARGET_NAME} PRIVATE -Wall -Werror)
 endif()

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -151,6 +151,16 @@ typedef enum JPH_SixDOFConstraintAxis {
     _JPH_SixDOFConstraintAxis_Force32 = 0x7FFFFFFF
 } JPH_SixDOFConstraintAxis;
 
+typedef enum JPH_StateRecorderState
+{
+    JPH_StateRecorderState_None = 0,
+    JPH_StateRecorderState_Global = 1,
+    JPH_StateRecorderState_Bodies = 2,
+    JPH_StateRecorderState_Contacts = 4,
+    JPH_StateRecorderState_Constraints = 8,
+    JPH_StateRecorderState_All = JPH_StateRecorderState_Global | JPH_StateRecorderState_Bodies | JPH_StateRecorderState_Contacts | JPH_StateRecorderState_Constraints
+} JPH_StateRecorderState;
+
 typedef struct JPH_Vec3 {
     float x;
     float y;
@@ -329,6 +339,8 @@ typedef struct JPH_BodyActivationListener       JPH_BodyActivationListener;
 
 typedef struct JPH_SharedMutex                  JPH_SharedMutex;
 
+typedef struct JPH_StateRecorder                JPH_StateRecorder;
+
 typedef struct JPH_BodyLockRead
 {
     const JPH_BodyLockInterface* lockInterface;
@@ -433,6 +445,9 @@ JPH_CAPI void JPH_PhysicsSystem_RemoveConstraint(JPH_PhysicsSystem* system, JPH_
 
 JPH_CAPI void JPH_PhysicsSystem_AddConstraints(JPH_PhysicsSystem* system, JPH_Constraint** constraints, uint32_t count);
 JPH_CAPI void JPH_PhysicsSystem_RemoveConstraints(JPH_PhysicsSystem* system, JPH_Constraint** constraints, uint32_t count);
+
+JPH_CAPI void JPH_PhysicsSystem_SaveState(JPH_PhysicsSystem* system, JPH_StateRecorder* recorder, JPH_StateRecorderState state);
+JPH_CAPI void JPH_PhysicsSystem_RestoreState(JPH_PhysicsSystem* system, JPH_StateRecorder* recorder);
 
 /* Math */
 JPH_CAPI void JPH_Quaternion_FromTo(const JPH_Vec3* from, const JPH_Vec3* to, JPH_Quat* quat);
@@ -940,6 +955,8 @@ JPH_CAPI void JPH_CharacterBase_GetGroundNormal(JPH_CharacterBase* character, JP
 JPH_CAPI void JPH_CharacterBase_GetGroundVelocity(JPH_CharacterBase* character, JPH_Vec3* velocity);
 JPH_CAPI JPH_BodyID JPH_CharacterBase_GetGroundBodyId(JPH_CharacterBase* character);
 JPH_CAPI JPH_SubShapeID JPH_CharacterBase_GetGroundSubShapeId(JPH_CharacterBase* character);
+JPH_CAPI void JPH_CharacterBase_SaveState(JPH_CharacterBase* character, JPH_StateRecorder* recorder);
+JPH_CAPI void JPH_CharacterBase_RestoreState(JPH_CharacterBase* character, JPH_StateRecorder* recorder);
 
 /* CharacterVirtualSettings */
 JPH_CAPI JPH_CharacterVirtualSettings* JPH_CharacterVirtualSettings_Create();
@@ -959,5 +976,19 @@ JPH_CAPI void JPH_CharacterVirtual_SetRotation(JPH_CharacterVirtual* character, 
 JPH_CAPI void JPH_CharacterVirtual_ExtendedUpdate(JPH_CharacterVirtual* character, float deltaTime,
 	const JPH_ExtendedUpdateSettings* settings, JPH_ObjectLayer layer, JPH_PhysicsSystem* system);
 JPH_CAPI void JPH_CharacterVirtual_RefreshContacts(JPH_CharacterVirtual* character, JPH_ObjectLayer layer, JPH_PhysicsSystem* system);
+
+/* StateRecorder */
+JPH_CAPI JPH_StateRecorder* JPH_StateRecorder_Create();
+JPH_CAPI void JPH_StateRecorder_Destroy(JPH_StateRecorder* recorder);
+JPH_CAPI void JPH_StateRecorder_SetValidating(JPH_StateRecorder* recorder, JPH_Bool32 validating);
+JPH_CAPI JPH_Bool32 JPH_StateRecorder_IsValidating(JPH_StateRecorder* recorder);
+JPH_CAPI void JPH_StateRecorder_Rewind(JPH_StateRecorder* recorder);
+JPH_CAPI void JPH_StateRecorder_Clear(JPH_StateRecorder* recorder);
+JPH_CAPI JPH_Bool32 JPH_StateRecorder_IsEOF(JPH_StateRecorder* recorder);
+JPH_CAPI JPH_Bool32 JPH_StateRecorder_IsFailed(JPH_StateRecorder* recorder);
+JPH_CAPI JPH_Bool32 JPH_StateRecorder_IsEqual(JPH_StateRecorder* recorder, JPH_StateRecorder* other);
+JPH_CAPI void JPH_StateRecorder_WriteBytes(JPH_StateRecorder* recorder, const void* data, size_t size);
+JPH_CAPI void JPH_StateRecorder_ReadBytes(JPH_StateRecorder* recorder, void* data, size_t size);
+JPH_CAPI size_t JPH_StateRecorder_GetSize(JPH_StateRecorder* recorder);
 
 #endif /* _JOLT_C_H */

--- a/src/joltc/joltc_assert.cpp
+++ b/src/joltc/joltc_assert.cpp
@@ -109,12 +109,22 @@ static_assert(JPH_SixDOFConstraintAxis_RotationX == (int)JPH::SixDOFConstraintSe
 static_assert(JPH_SixDOFConstraintAxis_RotationY == (int)JPH::SixDOFConstraintSettings::EAxis::RotationY);
 static_assert(JPH_SixDOFConstraintAxis_RotationZ == (int)JPH::SixDOFConstraintSettings::EAxis::RotationZ);
 
-// EGroundState
+// JPH_GroundState
 static_assert(sizeof(JPH::CharacterBase::EGroundState) == sizeof(JPH_GroundState));
 static_assert(JPH_GroundState_OnGround == (int)JPH::CharacterBase::EGroundState::OnGround);
 static_assert(JPH_GroundState_OnSteepGround == (int)JPH::CharacterBase::EGroundState::OnSteepGround);
 static_assert(JPH_GroundState_NotSupported == (int)JPH::CharacterBase::EGroundState::NotSupported);
 static_assert(JPH_GroundState_InAir == (int)JPH::CharacterBase::EGroundState::InAir);
+
+// JPH_StateRecorderState
+static_assert(sizeof(JPH_StateRecorderState) == sizeof(uint32_t));
+static_assert(JPH_StateRecorderState_None == (int)JPH::EStateRecorderState::None);
+static_assert(JPH_StateRecorderState_Global == (int)JPH::EStateRecorderState::Global);
+static_assert(JPH_StateRecorderState_Bodies == (int)JPH::EStateRecorderState::Bodies);
+static_assert(JPH_StateRecorderState_Bodies == (int)JPH::EStateRecorderState::Bodies);
+static_assert(JPH_StateRecorderState_Contacts == (int)JPH::EStateRecorderState::Contacts);
+static_assert(JPH_StateRecorderState_Constraints == (int)JPH::EStateRecorderState::Constraints);
+static_assert(JPH_StateRecorderState_All == (int)JPH::EStateRecorderState::All);
 
 static_assert(sizeof(JPH::SubShapeIDPair) == sizeof(JPH_SubShapeIDPair));
 static_assert(alignof(JPH::SubShapeIDPair) == alignof(JPH_SubShapeIDPair));


### PR DESCRIPTION
1. Add bindings for StateRecorderImpl.
2. Change some cmake instructions to suppress compilation warnings.