### PR TITLE
More Shape Methods

### DIFF
--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -1085,6 +1085,16 @@ void JPH_Shape_Destroy(JPH_Shape* shape)
     }
 }
 
+void JPH_Shape_SetUserData(JPH_Shape* shape, uint64_t userData)
+{
+    reinterpret_cast<JPH::Shape*>(shape)->SetUserData(userData);
+}
+
+uint64_t JPH_Shape_GetUserData(JPH_Shape* shape)
+{
+    return reinterpret_cast<JPH::Shape*>(shape)->GetUserData();
+}
+
 void JPH_Shape_GetLocalBounds(JPH_Shape* shape, JPH_AABox* result)
 {
 	JPH_ASSERT(shape);

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -1043,6 +1043,21 @@ void JPH_MutableCompoundShape_RemoveShape(JPH_MutableCompoundShape* shape, uint3
     reinterpret_cast<JPH::MutableCompoundShape*>(shape)->RemoveShape(index);
 }
 
+void JPH_MutableCompoundShape_ModifyShape(JPH_MutableCompoundShape* shape, uint32_t index, const JPH_Vec3* position, const JPH_Quat* rotation) {
+    auto joltShape = reinterpret_cast<JPH::MutableCompoundShape*>(shape);
+    joltShape->ModifyShape(index, ToVec3(position), ToQuat(rotation));
+}
+
+void JPH_MutableCompoundShape_ModifyShape2(JPH_MutableCompoundShape* shape, uint32_t index, const JPH_Vec3* position, const JPH_Quat* rotation, const JPH_Shape* newShape) {
+    auto joltShape = reinterpret_cast<JPH::MutableCompoundShape*>(shape);
+    auto joltNewShape = reinterpret_cast<const JPH::Shape*>(newShape);
+    joltShape->ModifyShape(index, ToVec3(position), ToQuat(rotation), joltNewShape);
+}
+
+void JPH_MutableCompoundShape_AdjustCenterOfMass(JPH_MutableCompoundShape* shape) {
+    reinterpret_cast<JPH::MutableCompoundShape*>(shape)->AdjustCenterOfMass();
+}
+
 /* RotatedTranslatedShape */
 JPH_RotatedTranslatedShapeSettings* JPH_RotatedTranslatedShapeSettings_Create(const JPH_Vec3* position, const JPH_Quat* rotation, JPH_ShapeSettings* shapeSettings)
 {

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -1033,6 +1033,16 @@ JPH_MutableCompoundShape* JPH_MutableCompoundShape_Create(const JPH_MutableCompo
     return reinterpret_cast<JPH_MutableCompoundShape*>(shape);
 }
 
+uint32_t JPH_MutableCompoundShape_AddShape(JPH_MutableCompoundShape* shape, const JPH_Vec3* position, const JPH_Quat* rotation, const JPH_Shape* child, uint32_t userData) {
+    auto joltShape = reinterpret_cast<JPH::MutableCompoundShape*>(shape);
+    auto joltChild = reinterpret_cast<const JPH::Shape*>(child);
+    return joltShape->AddShape(ToVec3(position), ToQuat(rotation), joltChild, userData);
+}
+
+void JPH_MutableCompoundShape_RemoveShape(JPH_MutableCompoundShape* shape, uint32_t index) {
+    reinterpret_cast<JPH::MutableCompoundShape*>(shape)->RemoveShape(index);
+}
+
 /* RotatedTranslatedShape */
 JPH_RotatedTranslatedShapeSettings* JPH_RotatedTranslatedShapeSettings_Create(const JPH_Vec3* position, const JPH_Quat* rotation, JPH_ShapeSettings* shapeSettings)
 {

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -515,6 +515,8 @@ JPH_CAPI JPH_RotatedTranslatedShape* JPH_RotatedTranslatedShape_Create(const JPH
 
 /* Shape */
 JPH_CAPI void JPH_Shape_Destroy(JPH_Shape* shape);
+JPH_CAPI void JPH_Shape_SetUserData(JPH_Shape* shape, uint64_t userData);
+JPH_CAPI uint64_t JPH_Shape_GetUserData(JPH_Shape* shape);
 JPH_CAPI void JPH_Shape_GetLocalBounds(JPH_Shape* shape, JPH_AABox* result);
 JPH_CAPI void JPH_Shape_GetMassProperties(const JPH_Shape* shape, JPH_MassProperties* result);
 JPH_CAPI void JPH_Shape_GetCenterOfMass(JPH_Shape* shape, JPH_Vec3* result);

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -508,6 +508,9 @@ JPH_CAPI JPH_MutableCompoundShapeSettings* JPH_MutableCompoundShapeSettings_Crea
 JPH_CAPI JPH_MutableCompoundShape* JPH_MutableCompoundShape_Create(const JPH_MutableCompoundShapeSettings* settings);
 JPH_CAPI uint32_t JPH_MutableCompoundShape_AddShape(const JPH_MutableCompoundShape* shape, const JPH_Vec3* position, const JPH_Quat* rotation, const JPH_Shape* child, uint32_t userData);
 JPH_CAPI void JPH_MutableCompoundShape_RemoveShape(const JPH_MutableCompoundShape* shape, uint32_t index);
+JPH_CAPI void JPH_MutableCompoundShape_ModifyShape(const JPH_MutableCompoundShape* shape, uint32_t index, const JPH_Vec3* position, const JPH_Quat* rotation);
+JPH_CAPI void JPH_MutableCompoundShape_ModifyShape2(const JPH_MutableCompoundShape* shape, uint32_t index, const JPH_Vec3* position, const JPH_Quat* rotation, const JPH_Shape* newShape);
+JPH_CAPI void JPH_MutableCompoundShape_AdjustCenterOfMass(const JPH_MutableCompoundShape* shape);
 
 /* RotatedTranslatedShape */
 JPH_CAPI JPH_RotatedTranslatedShapeSettings* JPH_RotatedTranslatedShapeSettings_Create(const JPH_Vec3* position, const JPH_Quat* rotation, JPH_ShapeSettings* shapeSettings);

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -506,6 +506,8 @@ JPH_CAPI JPH_StaticCompoundShapeSettings* JPH_StaticCompoundShapeSettings_Create
 /* MutableCompoundShape */
 JPH_CAPI JPH_MutableCompoundShapeSettings* JPH_MutableCompoundShapeSettings_Create(void);
 JPH_CAPI JPH_MutableCompoundShape* JPH_MutableCompoundShape_Create(const JPH_MutableCompoundShapeSettings* settings);
+JPH_CAPI uint32_t JPH_MutableCompoundShape_AddShape(const JPH_MutableCompoundShape* shape, const JPH_Vec3* position, const JPH_Quat* rotation, const JPH_Shape* child, uint32_t userData);
+JPH_CAPI void JPH_MutableCompoundShape_RemoveShape(const JPH_MutableCompoundShape* shape, uint32_t index);
 
 /* RotatedTranslatedShape */
 JPH_CAPI JPH_RotatedTranslatedShapeSettings* JPH_RotatedTranslatedShapeSettings_Create(const JPH_Vec3* position, const JPH_Quat* rotation, JPH_ShapeSettings* shapeSettings);


### PR DESCRIPTION
This adds the following to the C API:

- Adds `GetUserData`/`SetUserData` to the base `Shape` class (matches the methods on Body).
- Adds `AddShape`/`RemoveShape` to `MutableCompoundShape`.
- Adds `ModifyShape` and `AdjustCenterOfMass` to `MutableCompoundShape`.