### PR TITLE
BroadPhaseQuery/NarrowPhaseQuery

### DIFF
--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -892,10 +892,10 @@ internal static unsafe partial class JoltApi
 
     /* BodyLockInterface */
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern nint JPC_PhysicsSystem_GetBodyLockInterface(nint system);
+    public static extern nint JPH_PhysicsSystem_GetBodyLockInterface(nint system);
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern nint JPC_PhysicsSystem_GetBodyLockInterfaceNoLock(nint system);
+    public static extern nint JPH_PhysicsSystem_GetBodyLockInterfaceNoLock(nint system);
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
     public static extern void JPH_BodyLockInterface_LockRead(nint lockInterface, uint bodyID, out BodyLockRead @lock);
@@ -930,10 +930,10 @@ internal static unsafe partial class JoltApi
 
     /* BodyLockInterface */
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern nint JPC_PhysicsSystem_GetNarrowPhaseQuery(nint system);
+    public static extern nint JPH_PhysicsSystem_GetNarrowPhaseQuery(nint system);
 
     [DllImport(LibName, CallingConvention = CallingConvention.Cdecl)]
-    public static extern nint JPC_PhysicsSystem_GetNarrowPhaseQueryNoLock(nint system);
+    public static extern nint JPH_PhysicsSystem_GetNarrowPhaseQueryNoLock(nint system);
 
     [LibraryImport(LibName, EntryPoint = nameof(JPH_NarrowPhaseQuery_CastRay))]
     public static partial Bool32 JPH_NarrowPhaseQuery_CastRay(nint system,

--- a/src/JoltPhysicsSharp/PhysicsSystem.cs
+++ b/src/JoltPhysicsSharp/PhysicsSystem.cs
@@ -170,11 +170,11 @@ public sealed class PhysicsSystem : NativeObject
     public BodyInterface BodyInterface => new(JPH_PhysicsSystem_GetBodyInterface(Handle));
     public BodyInterface BodyInterfaceNoLock => new(JPH_PhysicsSystem_GetBodyInterfaceNoLock(Handle));
 
-    public BodyLockInterface BodyLockInterface => new(JPC_PhysicsSystem_GetBodyLockInterface(Handle));
-    public BodyLockInterface BodyLockInterfaceNoLock => new(JPC_PhysicsSystem_GetBodyLockInterfaceNoLock(Handle));
+    public BodyLockInterface BodyLockInterface => new(JPH_PhysicsSystem_GetBodyLockInterface(Handle));
+    public BodyLockInterface BodyLockInterfaceNoLock => new(JPH_PhysicsSystem_GetBodyLockInterfaceNoLock(Handle));
 
-    public NarrowPhaseQuery NarrowPhaseQuery => new(JPC_PhysicsSystem_GetNarrowPhaseQuery(Handle));
-    public NarrowPhaseQuery NarrowPhaseQueryNoLock => new(JPC_PhysicsSystem_GetNarrowPhaseQueryNoLock(Handle));
+    public NarrowPhaseQuery NarrowPhaseQuery => new(JPH_PhysicsSystem_GetNarrowPhaseQuery(Handle));
+    public NarrowPhaseQuery NarrowPhaseQueryNoLock => new(JPH_PhysicsSystem_GetNarrowPhaseQueryNoLock(Handle));
 
     public void OptimizeBroadPhase()
     {

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -3298,6 +3298,30 @@ JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CastRay2(const JPH_NarrowPhaseQuery* qu
     return collector.hadHit;
 }
 
+JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CollidePoint(const JPH_NarrowPhaseQuery* query,
+	const JPH_RVec3* point,
+	JPH_CollidePointCollector* callback, void* userData,
+	JPH_BroadPhaseLayerFilter* broadPhaseLayerFilter,
+	JPH_ObjectLayerFilter* objectLayerFilter,
+	JPH_BodyFilter* bodyFilter)
+{
+    JPH_ASSERT(query && point && callback);
+    auto joltQuery = reinterpret_cast<const JPH::NarrowPhaseQuery*>(query);
+    auto joltPoint = ToJolt(point);
+
+    CollidePointCollectorCallback collector(callback, userData);
+
+    joltQuery->CollidePoint(
+        joltPoint,
+        collector,
+        ToJolt(broadPhaseLayerFilter),
+        ToJolt(objectLayerFilter),
+        ToJolt(bodyFilter)
+    );
+
+    return collector.hadHit;
+}
+
 JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CollideShape(const JPH_NarrowPhaseQuery* query,
     const JPH_Shape* shape, const JPH_Vec3* scale, const JPH_RMatrix4x4* centerOfMassTransform,
     JPH_RVec3* baseOffset,

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -3057,7 +3057,9 @@ public:
         JPH_BroadPhaseCastResult hit;
         hit.bodyID = result.mBodyID.GetIndexAndSequenceNumber();
         hit.fraction = result.mFraction;
-        proc(userData, &hit);
+
+        float fraction = proc(userData, &hit);
+        UpdateEarlyOutFraction(fraction);
         hadHit = true;
     }
 
@@ -3147,7 +3149,9 @@ public:
         hit.bodyID = result.mBodyID.GetIndexAndSequenceNumber();
         hit.fraction = result.mFraction;
         hit.subShapeID2 = result.mSubShapeID2.GetValue();
-        proc(userData, &hit);
+
+        float fraction = proc(userData, &hit);
+        UpdateEarlyOutFraction(fraction);
         hadHit = true;
     }
 
@@ -3166,7 +3170,9 @@ public:
         JPH_CollidePointResult hit;
         hit.bodyID = result.mBodyID.GetIndexAndSequenceNumber();
         hit.subShapeID2 = result.mSubShapeID2.GetValue();
-        proc(userData, &hit);
+
+        float fraction = proc(userData, &hit);
+        UpdateEarlyOutFraction(fraction);
         hadHit = true;
     }
 
@@ -3190,7 +3196,9 @@ public:
         hit.subShapeID1 = result.mSubShapeID1.GetValue();
         hit.subShapeID2 = result.mSubShapeID2.GetValue();
         hit.bodyID2 = result.mBodyID2.GetIndexAndSequenceNumber();
-        proc(userData, &hit);
+
+        float fraction = proc(userData, &hit);
+        UpdateEarlyOutFraction(fraction);
         hadHit = true;
     }
 
@@ -3216,7 +3224,9 @@ public:
         hit.bodyID2 = result.mBodyID2.GetIndexAndSequenceNumber();
         hit.fraction = result.mFraction;
         hit.isBackFaceHit = result.mIsBackFaceHit;
-        proc(userData, &hit);
+
+        float fraction = proc(userData, &hit);
+        UpdateEarlyOutFraction(fraction);
         hadHit = true;
     }
 

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -3086,7 +3086,7 @@ public:
 	uint32_t _padding;
 };
 
-JPH_CAPI JPH_Bool32 JPH_BroadPhaseQuery_CastRay(const JPH_BroadPhaseQuery* query,
+JPH_Bool32 JPH_BroadPhaseQuery_CastRay(const JPH_BroadPhaseQuery* query,
     const JPH_Vec3* origin, const JPH_Vec3* direction,
     JPH_RayCastBodyCollector* callback, void* userData,
     JPH_BroadPhaseLayerFilter* broadPhaseLayerFilter,
@@ -3100,7 +3100,7 @@ JPH_CAPI JPH_Bool32 JPH_BroadPhaseQuery_CastRay(const JPH_BroadPhaseQuery* query
     return collector.hadHit;
 }
 
-JPH_CAPI JPH_Bool32 JPH_BroadPhaseQuery_CollideAABox(const JPH_BroadPhaseQuery* query,
+JPH_Bool32 JPH_BroadPhaseQuery_CollideAABox(const JPH_BroadPhaseQuery* query,
     const JPH_AABox* box, JPH_CollideShapeBodyCollector* callback, void* userData,
     JPH_BroadPhaseLayerFilter* broadPhaseLayerFilter,
     JPH_ObjectLayerFilter* objectLayerFilter)
@@ -3113,7 +3113,7 @@ JPH_CAPI JPH_Bool32 JPH_BroadPhaseQuery_CollideAABox(const JPH_BroadPhaseQuery* 
     return collector.hadHit;
 }
 
-JPH_CAPI JPH_Bool32 JPH_BroadPhaseQuery_CollideSphere(const JPH_BroadPhaseQuery* query,
+JPH_Bool32 JPH_BroadPhaseQuery_CollideSphere(const JPH_BroadPhaseQuery* query,
     const JPH_Vec3* center, float radius, JPH_CollideShapeBodyCollector* callback, void* userData,
     JPH_BroadPhaseLayerFilter* broadPhaseLayerFilter,
     JPH_ObjectLayerFilter* objectLayerFilter)
@@ -3125,7 +3125,7 @@ JPH_CAPI JPH_Bool32 JPH_BroadPhaseQuery_CollideSphere(const JPH_BroadPhaseQuery*
     return collector.hadHit;
 }
 
-JPH_CAPI JPH_Bool32 JPH_BroadPhaseQuery_CollidePoint(const JPH_BroadPhaseQuery* query,
+JPH_Bool32 JPH_BroadPhaseQuery_CollidePoint(const JPH_BroadPhaseQuery* query,
     const JPH_Vec3* point, JPH_CollideShapeBodyCollector* callback, void* userData,
     JPH_BroadPhaseLayerFilter* broadPhaseLayerFilter,
     JPH_ObjectLayerFilter* objectLayerFilter)
@@ -3272,7 +3272,7 @@ JPH_Bool32 JPH_NarrowPhaseQuery_CastRay(const JPH_NarrowPhaseQuery* query,
     return hadHit;
 }
 
-JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CastRay2(const JPH_NarrowPhaseQuery* query,
+JPH_Bool32 JPH_NarrowPhaseQuery_CastRay2(const JPH_NarrowPhaseQuery* query,
     const JPH_RVec3* origin, const JPH_Vec3* direction,
     JPH_CastRayCollector* callback, void* userData,
     JPH_BroadPhaseLayerFilter* broadPhaseLayerFilter,
@@ -3298,7 +3298,7 @@ JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CastRay2(const JPH_NarrowPhaseQuery* qu
     return collector.hadHit;
 }
 
-JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CollidePoint(const JPH_NarrowPhaseQuery* query,
+JPH_Bool32 JPH_NarrowPhaseQuery_CollidePoint(const JPH_NarrowPhaseQuery* query,
 	const JPH_RVec3* point,
 	JPH_CollidePointCollector* callback, void* userData,
 	JPH_BroadPhaseLayerFilter* broadPhaseLayerFilter,
@@ -3322,7 +3322,7 @@ JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CollidePoint(const JPH_NarrowPhaseQuery
     return collector.hadHit;
 }
 
-JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CollideShape(const JPH_NarrowPhaseQuery* query,
+JPH_Bool32 JPH_NarrowPhaseQuery_CollideShape(const JPH_NarrowPhaseQuery* query,
     const JPH_Shape* shape, const JPH_Vec3* scale, const JPH_RMatrix4x4* centerOfMassTransform,
     JPH_RVec3* baseOffset,
     JPH_CollideShapeCollector* callback, void* userData,
@@ -3358,7 +3358,7 @@ JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CollideShape(const JPH_NarrowPhaseQuery
     return collector.hadHit;
 }
 
-JPH_CAPI JPH_Bool32 JPH_NarrowPhaseQuery_CastShape(const JPH_NarrowPhaseQuery* query,
+JPH_Bool32 JPH_NarrowPhaseQuery_CastShape(const JPH_NarrowPhaseQuery* query,
     const JPH_Shape* shape,
     const JPH_RMatrix4x4* worldTransform, const JPH_Vec3* direction,
     JPH_RVec3* baseOffset,

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -3063,9 +3063,10 @@ public:
         hadHit = true;
     }
 
-    bool hadHit = false;
     JPH_RayCastBodyCollector* proc;
     void* userData;
+    JPH_Bool32 hadHit = false;
+	uint32_t _padding;
 };
 
 class CollideShapeBodyCollectorCallback : public CollideShapeBodyCollector
@@ -3079,9 +3080,10 @@ public:
         hadHit = true;
     }
 
-    bool hadHit = false;
     JPH_CollideShapeBodyCollector* proc;
     void* userData;
+    JPH_Bool32 hadHit = false;
+	uint32_t _padding;
 };
 
 JPH_CAPI JPH_Bool32 JPH_BroadPhaseQuery_CastRay(const JPH_BroadPhaseQuery* query,
@@ -3155,9 +3157,10 @@ public:
         hadHit = true;
     }
 
-    bool hadHit = false;
     JPH_CastRayCollector* proc;
     void* userData;
+    JPH_Bool32 hadHit = false;
+	uint32_t _padding;
 };
 
 class CollidePointCollectorCallback : public CollidePointCollector
@@ -3176,9 +3179,10 @@ public:
         hadHit = true;
     }
 
-    bool hadHit = false;
     JPH_CollidePointCollector* proc;
     void* userData;
+    JPH_Bool32 hadHit = false;
+	uint32_t _padding;
 };
 
 class CollideShapeCollectorCallback : public CollideShapeCollector
@@ -3202,9 +3206,10 @@ public:
         hadHit = true;
     }
 
-    bool hadHit = false;
     JPH_CollideShapeCollector* proc;
     void* userData;
+    JPH_Bool32 hadHit = false;
+	uint32_t _padding;
 };
 
 class CastShapeCollectorCallback : public CastShapeCollector
@@ -3230,9 +3235,10 @@ public:
         hadHit = true;
     }
 
-    bool hadHit = false;
     JPH_CastShapeCollector* proc;
     void* userData;
+    JPH_Bool32 hadHit = false;
+	uint32_t _padding;
 };
 
 JPH_Bool32 JPH_NarrowPhaseQuery_CastRay(const JPH_NarrowPhaseQuery* query,

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -530,8 +530,8 @@ const JPH_BodyLockInterface* JPH_PhysicsSystem_GetBodyLockInterfaceNoLock(const 
 /* JPH_BroadPhaseLayerFilter */
 static const JPH::BroadPhaseLayerFilter& ToJolt(JPH_BroadPhaseLayerFilter* bpFilter)
 {
-    JPH::BroadPhaseLayerFilter fallback;
-    return bpFilter ? *reinterpret_cast<JPH::BroadPhaseLayerFilter*>(bpFilter) : fallback;
+    static const JPH::BroadPhaseLayerFilter g_defaultBroadPhaseLayerFilter = {};
+    return bpFilter ? *reinterpret_cast<JPH::BroadPhaseLayerFilter*>(bpFilter) : g_defaultBroadPhaseLayerFilter;
 }
 
 class ManagedBroadPhaseLayerFilter final : public JPH::BroadPhaseLayerFilter
@@ -582,8 +582,8 @@ void JPH_BroadPhaseLayerFilter_Destroy(JPH_BroadPhaseLayerFilter* filter)
 /* JPH_ObjectLayerFilter */
 static const JPH::ObjectLayerFilter& ToJolt(JPH_ObjectLayerFilter* opFilter)
 {
-    JPH::ObjectLayerFilter fallback;
-    return opFilter ? *reinterpret_cast<JPH::ObjectLayerFilter*>(opFilter) : fallback;
+    static const JPH::ObjectLayerFilter g_defaultObjectLayerFilter = {};
+    return opFilter ? *reinterpret_cast<JPH::ObjectLayerFilter*>(opFilter) : g_defaultObjectLayerFilter;
 }
 
 class ManagedObjectLayerFilter final : public JPH::ObjectLayerFilter
@@ -634,8 +634,8 @@ void JPH_ObjectLayerFilter_Destroy(JPH_ObjectLayerFilter* filter)
 /* JPH_BodyFilter */
 static const JPH::BodyFilter& ToJolt(JPH_BodyFilter* bodyFilter)
 {
-    JPH::BodyFilter fallback;
-    return bodyFilter ? *reinterpret_cast<JPH::BodyFilter*>(bodyFilter) : fallback;
+    static const JPH::BodyFilter g_defaultBodyFilter = {};
+    return bodyFilter ? *reinterpret_cast<JPH::BodyFilter*>(bodyFilter) : g_defaultBodyFilter;
 }
 
 class ManagedBodyFilter final : public JPH::BodyFilter


### PR DESCRIPTION
This exposes `BroadPhaseQuery` and more of the `NarrowPhaseQuery` methods.

I didn't like the existing collector objects because they required excessive heap allocation and didn't allow the application to control early exit behavior.   I converted them to C callback functions, and internally the bindings create a C++ collector class that calls the C callback for every hit.  This gives the application more control over how it handles the hits -- it could append to a list, track the closest hit, do custom filtering, immediately cancel the raycast on the first hit, etc.