### PR TITLE
Mass Methods

### DIFF
--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -2709,16 +2709,36 @@ float JPH_MotionProperties_GetAngularDamping(const JPH_MotionProperties* propert
     return reinterpret_cast<const JPH::MotionProperties*>(properties)->GetAngularDamping();
 }
 
-float JPH_MotionProperties_GetInverseMassUnchecked(JPH_MotionProperties* properties)
-{
-    return reinterpret_cast<JPH::MotionProperties*>(properties)->GetInverseMassUnchecked();
-}
-
 void JPH_MotionProperties_SetMassProperties(JPH_MotionProperties* properties, JPH_AllowedDOFs allowedDOFs, const JPH_MassProperties* massProperties)
 {
     reinterpret_cast<JPH::MotionProperties*>(properties)->SetMassProperties(
         static_cast<EAllowedDOFs>(allowedDOFs),
         ToJolt(massProperties));
+}
+
+float JPH_MotionProperties_GetInverseMassUnchecked(JPH_MotionProperties* properties)
+{
+    return reinterpret_cast<JPH::MotionProperties*>(properties)->GetInverseMassUnchecked();
+}
+
+void JPH_MotionProperties_SetInverseMass(JPH_MotionProperties* properties, float inverseMass)
+{
+    reinterpret_cast<JPH::MotionProperties*>(properties)->SetInverseMass(inverseMass);
+}
+
+void JPH_MotionProperties_GetInverseInertiaDiagonal(JPH_MotionProperties* properties, JPH_Vec3* result)
+{
+    FromJolt(reinterpret_cast<JPH::MotionProperties*>(properties)->GetInverseInertiaDiagonal(), result);
+}
+
+void JPH_MotionProperties_GetInertiaRotation(JPH_MotionProperties* properties, JPH_Quat* result)
+{
+    FromJolt(reinterpret_cast<JPH::MotionProperties*>(properties)->GetInertiaRotation(), result);
+}
+
+void JPH_MotionProperties_SetInverseInertia(JPH_MotionProperties* properties, JPH_Vec3* diagonal, JPH_Quat* rot)
+{
+    reinterpret_cast<JPH::MotionProperties*>(properties)->SetInverseInertia(ToJolt(diagonal), ToJolt(rot));
 }
 
 const JPH_BroadPhaseQuery* JPH_PhysicsSystem_GetBroadPhaseQuery(const JPH_PhysicsSystem* system)

--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -269,6 +269,15 @@ static inline JPH::MotorSettings ToJolt(const JPH_MotorSettings* settings)
     return result;
 }
 
+void JPH_MassProperties_DecomposePrincipalMomentsOfInertia(JPH_MassProperties* properties, JPH_Matrix4x4* rotation, JPH_Vec3* diagonal)
+{
+	JPH::Mat44 joltRotation;
+	JPH::Vec3 joltDiagonal;
+	reinterpret_cast<JPH::MassProperties*>(properties)->DecomposePrincipalMomentsOfInertia(joltRotation, joltDiagonal);
+	FromJolt(joltRotation, rotation);
+	FromJolt(joltDiagonal, diagonal);
+}
+
 void JPH_MassProperties_ScaleToMass(JPH_MassProperties* properties, float mass)
 {
     reinterpret_cast<JPH::MassProperties*>(properties)->ScaleToMass(mass);

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -1066,6 +1066,7 @@ JPH_CAPI void JPH_MotionProperties_SetInverseInertia(JPH_MotionProperties* prope
 //--------------------------------------------------------------------------------------------------
 // JPH_MassProperties
 //--------------------------------------------------------------------------------------------------
+JPH_CAPI void JPH_MassProperties_DecomposePrincipalMomentsOfInertia(JPH_MassProperties* properties, JPH_Matrix4x4* rotation, JPH_Vec3* diagonal);
 JPH_CAPI void JPH_MassProperties_ScaleToMass(JPH_MassProperties* properties, float mass);
 
 //--------------------------------------------------------------------------------------------------

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -1056,8 +1056,12 @@ JPH_CAPI void JPH_MotionProperties_SetLinearDamping(JPH_MotionProperties* proper
 JPH_CAPI float JPH_MotionProperties_GetLinearDamping(const JPH_MotionProperties* properties);
 JPH_CAPI void JPH_MotionProperties_SetAngularDamping(JPH_MotionProperties* properties, float damping);
 JPH_CAPI float JPH_MotionProperties_GetAngularDamping(const JPH_MotionProperties* properties);
-JPH_CAPI float JPH_MotionProperties_GetInverseMassUnchecked(JPH_MotionProperties* properties);
 JPH_CAPI void JPH_MotionProperties_SetMassProperties(JPH_MotionProperties* properties, JPH_AllowedDOFs allowedDOFs, const JPH_MassProperties* massProperties);
+JPH_CAPI float JPH_MotionProperties_GetInverseMassUnchecked(JPH_MotionProperties* properties);
+JPH_CAPI void JPH_MotionProperties_SetInverseMass(JPH_MotionProperties* properties, float inverseMass);
+JPH_CAPI void JPH_MotionProperties_GetInverseInertiaDiagonal(JPH_MotionProperties* properties, JPH_Vec3* result);
+JPH_CAPI void JPH_MotionProperties_GetInertiaRotation(JPH_MotionProperties* properties, JPH_Quat* result);
+JPH_CAPI void JPH_MotionProperties_SetInverseInertia(JPH_MotionProperties* properties, JPH_Vec3* diagonal, JPH_Quat* rot);
 
 //--------------------------------------------------------------------------------------------------
 // JPH_MassProperties


### PR DESCRIPTION
Add a few missing mass/inertia methods, allowing us to change the mass/inertia manually without using MassProperties.