### PR TITLE
Add JPH_Body_GetFixedToWorldBody;

### DIFF
--- a/src/joltc/joltc.cpp
+++ b/src/joltc/joltc.cpp
@@ -2519,8 +2519,8 @@ float JPH_ConeConstraintSettings_GetHalfConeAngle(JPH_ConeConstraintSettings* se
 
 JPH_ConeConstraint* JPH_ConeConstraintSettings_CreateConstraint(JPH_ConeConstraintSettings* settings, JPH_Body* body1, JPH_Body* body2)
 {
-	auto joltBody1 = body1 ? reinterpret_cast<JPH::Body*>(body1) : &JPH::Body::sFixedToWorld;
-    auto joltBody2 = body2 ? reinterpret_cast<JPH::Body*>(body2) : &JPH::Body::sFixedToWorld;
+    auto joltBody1 = reinterpret_cast<JPH::Body*>(body1);
+    auto joltBody2 = reinterpret_cast<JPH::Body*>(body2);
     JPH::TwoBodyConstraint* constraint = reinterpret_cast<JPH::ConeConstraintSettings*>(settings)->Create(*joltBody1, *joltBody2);
     constraint->AddRef();
 
@@ -4280,6 +4280,11 @@ void JPH_Body_SetUserData(JPH_Body* body, uint64_t userData)
 uint64_t JPH_Body_GetUserData(JPH_Body* body)
 {
     return reinterpret_cast<JPH::Body*>(body)->GetUserData();
+}
+
+JPH_Body* JPH_Body_GetFixedToWorldBody(void)
+{
+	return reinterpret_cast<JPH_Body*>(&JPH::Body::sFixedToWorld);
 }
 
 /* Contact Listener */

--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -1242,6 +1242,7 @@ JPH_CAPI void JPH_Body_GetCenterOfMassTransform(const JPH_Body* body, JPH_RMatri
 JPH_CAPI void JPH_Body_SetUserData(JPH_Body* body, uint64_t userData);
 JPH_CAPI uint64_t JPH_Body_GetUserData(JPH_Body* body);
 
+JPH_CAPI JPH_Body* JPH_Body_GetFixedToWorldBody(void);
 
 /* JPH_BroadPhaseLayerFilter_Procs */
 typedef struct JPH_BroadPhaseLayerFilter_Procs {


### PR DESCRIPTION
`JPH::Body::sFixedToWorld` lets you create a constraint with only 1 body, which can be convenient.

I accidentally added support for this on ConeConstraint by allowing the body pointers to be NULL and defaulting to `sFixedToWorld`.  We could add the same behavior to all the other constraints, but it seems cleaner to just expose the `sFixedToWorld` body directly.

Let me know if you want any name changes or anything!