### PR TITLE
Remove overly-safe cast checks

### DIFF
--- a/src/joltc/joltc.h
+++ b/src/joltc/joltc.h
@@ -346,7 +346,6 @@ typedef struct JPH_BroadPhaseCastResult {
     float          fraction;
 } JPH_BroadPhaseCastResult;
 
-// NOTE: Needs to be kept in sync with JPH::RayCastResult
 typedef struct JPH_RayCastResult {
     JPH_BodyID     bodyID;
     float          fraction;
@@ -358,7 +357,6 @@ typedef struct JPH_CollidePointResult {
 	JPH_SubShapeID subShapeID2;
 } JPH_CollidePointResult;
 
-// NOTE: Needs to be kept in sync with JPH::ShapeCastResult
 typedef struct JPH_CollideShapeResult
 {
     JPH_Vec3           contactPointOn1;

--- a/src/joltc/joltc_assert.cpp
+++ b/src/joltc/joltc_assert.cpp
@@ -33,10 +33,6 @@ __pragma(warning(push, 0))
 __pragma(warning(pop))
 #endif
 
-#ifdef JPH_COMPILER_GCC
-JPH_GCC_SUPPRESS_WARNING("-Winvalid-offsetof")
-#endif
-
 #define ENSURE_SIZE_ALIGN(type0, type1) \
     static_assert(sizeof(type0) == sizeof(type1)); \
     static_assert(alignof(type0) == alignof(type1))
@@ -180,10 +176,5 @@ static_assert(JPH_BackFaceMode_CollideWithBackFaces == (int)JPH::EBackFaceMode::
 
 static_assert(sizeof(JPH::SubShapeIDPair) == sizeof(JPH_SubShapeIDPair));
 static_assert(alignof(JPH::SubShapeIDPair) == alignof(JPH_SubShapeIDPair));
-
-ENSURE_SIZE_ALIGN(JPH::RayCastResult, JPH_RayCastResult);
-static_assert(offsetof(JPH::RayCastResult, mBodyID) == offsetof(JPH_RayCastResult, bodyID));
-static_assert(offsetof(JPH::RayCastResult, mFraction) == offsetof(JPH_RayCastResult, fraction));
-static_assert(offsetof(JPH::RayCastResult, mSubShapeID2) == offsetof(JPH_RayCastResult, subShapeID2));
 
 //static_assert(offsetof(JPH::MassProperties, mMass) == offsetof(JPH_MassProperties, mass));


### PR DESCRIPTION
In 16143847c05f23dffc48355c35a9fe3f7279f9f7, raycast was added, with casts between `JPH::RayCastResult` and `JPH_RayCastResult`.  It was a good idea to have static asserts and comments to make sure that the two structs didn't get out of sync.  However, it's no longer necessary, since now we copy the fields instead of casting.

*Why* I actually want to remove these: I tried compiling JoltC to WASM and got some compile errors about how you can't use `offsetof` on a C++ class.  joltc_assert was already silencing these for GCC, but emcc uses clang and clang's warnings weren't silenced.  Rather than add the warning suppression for clang, it's easier to remove these outdated asserts altogether.

After this change, I can confirm that JoltC compiles to WASM successfully 🎉 