### PR TITLE
Fix MassProperties.ScaleToMass by setting Matrix4x4Extensions.SetColumn to use ref this

### DIFF
--- a/src/JoltPhysicsSharp/Matrix4x4Extensions.cs
+++ b/src/JoltPhysicsSharp/Matrix4x4Extensions.cs
@@ -12,7 +12,7 @@ public static class Matrix4x4Extensions
         return new(matrix[0, j], matrix[1, j], matrix[2,j], matrix[3,j]);
     }
 
-    public static void SetColumn(this Matrix4x4 matrix, int j, Vector4 value)
+    public static void SetColumn(ref this Matrix4x4 matrix, int j, Vector4 value)
     {
         matrix[0, j] = value.X;
         matrix[1, j] = value.Y;

--- a/src/JoltPhysicsSharp/Matrix4x4Extensions.cs
+++ b/src/JoltPhysicsSharp/Matrix4x4Extensions.cs
@@ -7,7 +7,7 @@ namespace JoltPhysicsSharp;
 
 public static class Matrix4x4Extensions
 {
-    public static Vector4 GetColumn(this Matrix4x4 matrix, int j)
+    public static Vector4 GetColumn(in this Matrix4x4 matrix, int j)
     {
         return new(matrix[0, j], matrix[1, j], matrix[2,j], matrix[3,j]);
     }


### PR DESCRIPTION
Previously the extension method was being passed a copy of the matrix, resulting in no changes being made to the inertia tensor, and the inertia tensor not scaling with mass.