### PR TITLE
Add VehicleTrack bindings and VehicleConstraint properties

### DIFF
--- a/src/JoltPhysicsSharp/JoltApi.cs
+++ b/src/JoltPhysicsSharp/JoltApi.cs
@@ -3298,6 +3298,18 @@ internal static unsafe partial class JoltApi
         public float engineTorqueRatio;
     }
 
+
+    public struct JPH_VehicleTrackSettings
+    {
+        public uint drivenWheel;
+        public unsafe uint* wheels;
+        public uint wheelsCount;
+        public float inertia;
+        public float angularDamping;
+        public float maxBrakeTorque;
+        public float differentialRatio;
+    }
+
     [LibraryImport(LibName)]
     public static partial void JPH_VehicleAntiRollBar_Init(JPH_VehicleAntiRollBar* settings);
 
@@ -3854,6 +3866,29 @@ internal static unsafe partial class JoltApi
 
     [LibraryImport(LibName)]
     public static partial nint JPH_TrackedVehicleController_GetTransmission(nint controller);
+
+    [LibraryImport(LibName)]
+    public static partial nint JPH_TrackedVehicleController_GetTrack(nint controller, TrackSide side);
+    #endregion
+
+    #region VehicleTrack
+    [LibraryImport(LibName)]
+    public static partial void JPH_VehicleTrackSettings_Init(JPH_VehicleTrackSettings* settings);
+
+    [LibraryImport(LibName)]
+    public static partial float JPH_VehicleTrack_GetAngularVelocity(nint track);
+    [LibraryImport(LibName)]
+    public static partial void JPH_VehicleTrack_SetAngularVelocity(nint track, float velocity);
+    [LibraryImport(LibName)]
+    public static partial uint JPH_VehicleTrack_GetDrivenWheel(nint track);
+    [LibraryImport(LibName)]
+    public static partial float JPH_VehicleTrack_GetInertia(nint track);
+    [LibraryImport(LibName)]
+    public static partial float JPH_VehicleTrack_GetAngularDamping(nint track);
+    [LibraryImport(LibName)]
+    public static partial float JPH_VehicleTrack_GetMaxBrakeTorque(nint track);
+    [LibraryImport(LibName)]
+    public static partial float JPH_VehicleTrack_GetDifferentialRatio(nint track);
     #endregion
 
     sealed class UTF8EncodingRelaxed : UTF8Encoding

--- a/src/JoltPhysicsSharp/Vehicle/TrackSide.cs
+++ b/src/JoltPhysicsSharp/Vehicle/TrackSide.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+namespace JoltPhysicsSharp;
+
+public enum TrackSide
+{
+    Left = 0,
+    Right = 1
+}

--- a/src/JoltPhysicsSharp/Vehicle/TrackedVehicleController.cs
+++ b/src/JoltPhysicsSharp/Vehicle/TrackedVehicleController.cs
@@ -92,7 +92,6 @@ public unsafe class TrackedVehicleControllerSettings : VehicleControllerSettings
         }
     }
 
-    // TODO: VehicleTrackSettings
 }
 
 public class TrackedVehicleController : VehicleController
@@ -140,4 +139,12 @@ public class TrackedVehicleController : VehicleController
     {
         get => VehicleTransmission.GetObject(JPH_TrackedVehicleController_GetTransmission(Handle))!;
     }
+
+    public VehicleTrack GetTrack(TrackSide side)
+    {
+        return VehicleTrack.GetObject(JPH_TrackedVehicleController_GetTrack(Handle, side))!;
+    }
+
+    public VehicleTrack LeftTrack => GetTrack(TrackSide.Left);
+    public VehicleTrack RightTrack => GetTrack(TrackSide.Right);
 }

--- a/src/JoltPhysicsSharp/Vehicle/VehicleConstraint.cs
+++ b/src/JoltPhysicsSharp/Vehicle/VehicleConstraint.cs
@@ -25,6 +25,33 @@ public class VehicleConstraint : Constraint, IPhysicsStepListener
         get => Body.GetObject(JPH_VehicleConstraint_GetVehicleBody(Handle))!;
     }
 
+    public Vector3 LocalForward
+    {
+        get
+        {
+            JPH_VehicleConstraint_GetLocalForward(Handle, out Vector3 result);
+            return result;
+        }
+    }
+
+    public Vector3 LocalUp
+    {
+        get
+        {
+            JPH_VehicleConstraint_GetLocalUp(Handle, out Vector3 result);
+            return result;
+        }
+    }
+
+    public Vector3 WorldUp
+    {
+        get
+        {
+            JPH_VehicleConstraint_GetWorldUp(Handle, out Vector3 result);
+            return result;
+        }
+    }
+
     public T GetController<T>() where T : VehicleController
     {
         return VehicleController.GetObject<T>(JPH_VehicleConstraint_GetController(Handle))!;

--- a/src/JoltPhysicsSharp/Vehicle/VehicleTrack.cs
+++ b/src/JoltPhysicsSharp/Vehicle/VehicleTrack.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+using static JoltPhysicsSharp.JoltApi;
+
+namespace JoltPhysicsSharp;
+
+public sealed class VehicleTrack : NativeObject
+{
+    internal VehicleTrack(nint handle, bool owns = false)
+        : base(handle, owns)
+    {
+    }
+
+    internal static VehicleTrack? GetObject(nint handle) => GetOrAddObject(handle, h => new VehicleTrack(h, false));
+
+    public float AngularVelocity
+    {
+        get => JPH_VehicleTrack_GetAngularVelocity(Handle);
+        set => JPH_VehicleTrack_SetAngularVelocity(Handle, value);
+    }
+
+    public uint DrivenWheel => JPH_VehicleTrack_GetDrivenWheel(Handle);
+    public float Inertia => JPH_VehicleTrack_GetInertia(Handle);
+    public float AngularDamping => JPH_VehicleTrack_GetAngularDamping(Handle);
+    public float MaxBrakeTorque => JPH_VehicleTrack_GetMaxBrakeTorque(Handle);
+    public float DifferentialRatio => JPH_VehicleTrack_GetDifferentialRatio(Handle);
+}

--- a/src/JoltPhysicsSharp/Vehicle/VehicleTrackSettings.cs
+++ b/src/JoltPhysicsSharp/Vehicle/VehicleTrackSettings.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+using static JoltPhysicsSharp.JoltApi;
+
+namespace JoltPhysicsSharp;
+
+public struct VehicleTrackSettings
+{
+    public uint DrivenWheel { get; set; }
+    public uint[]? Wheels { get; set; }
+    public float Inertia { get; set; }
+    public float AngularDamping { get; set; }
+    public float MaxBrakeTorque { get; set; }
+    public float DifferentialRatio { get; set; }
+
+    public unsafe VehicleTrackSettings()
+    {
+        JPH_VehicleTrackSettings native;
+        JPH_VehicleTrackSettings_Init(&native);
+
+        FromNative(native);
+    }
+
+    internal unsafe void FromNative(in JPH_VehicleTrackSettings native)
+    {
+        DrivenWheel = native.drivenWheel;
+        Inertia = native.inertia;
+        AngularDamping = native.angularDamping;
+        MaxBrakeTorque = native.maxBrakeTorque;
+        DifferentialRatio = native.differentialRatio;
+
+        if (native.wheelsCount > 0 && native.wheels != null)
+        {
+            Wheels = new uint[native.wheelsCount];
+            for (int i = 0; i < native.wheelsCount; i++)
+            {
+                Wheels[i] = native.wheels[i];
+            }
+        }
+    }
+
+    internal unsafe void ToNative(JPH_VehicleTrackSettings* native, uint* wheelsBuffer)
+    {
+        native->drivenWheel = DrivenWheel;
+        native->inertia = Inertia;
+        native->angularDamping = AngularDamping;
+        native->maxBrakeTorque = MaxBrakeTorque;
+        native->differentialRatio = DifferentialRatio;
+
+        if (Wheels is { Length: > 0 })
+        {
+            for (int i = 0; i < Wheels.Length; i++)
+            {
+                wheelsBuffer[i] = Wheels[i];
+            }
+            native->wheels = wheelsBuffer;
+            native->wheelsCount = (uint)Wheels.Length;
+        }
+        else
+        {
+            native->wheels = null;
+            native->wheelsCount = 0;
+        }
+    }
+}

--- a/tests/VehicleTests.cs
+++ b/tests/VehicleTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) Amer Koleci and Contributors.
+// Licensed under the MIT License (MIT). See LICENSE in the repository root for more information.
+
+using NUnit.Framework;
+
+namespace JoltPhysicsSharp.Tests;
+
+[TestFixture(TestOf = typeof(VehicleConstraint))]
+public class VehicleTests : BaseTest
+{
+    [Test]
+    public void TestTrackSideEnum()
+    {
+        Assert.That((int)TrackSide.Left, Is.EqualTo(0));
+        Assert.That((int)TrackSide.Right, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TestVehicleTrackSettingsDefault()
+    {
+        // Test native initialization with default values
+        VehicleTrackSettings settings = new();
+
+        Assert.That(settings.DrivenWheel, Is.EqualTo(0u));
+        Assert.That(settings.Inertia, Is.GreaterThan(0f));
+        Assert.That(settings.AngularDamping, Is.GreaterThanOrEqualTo(0f));
+        Assert.That(settings.MaxBrakeTorque, Is.GreaterThan(0f));
+        Assert.That(settings.DifferentialRatio, Is.GreaterThan(0f));
+    }
+
+    [Test]
+    public void TestVehicleTrackSettingsManualInit()
+    {
+        // Test manual initialization without calling native Init
+        VehicleTrackSettings settings = default;
+        settings.DrivenWheel = 1;
+        settings.Wheels = [0, 1, 2, 3];
+        settings.Inertia = 5.0f;
+        settings.AngularDamping = 0.5f;
+        settings.MaxBrakeTorque = 1000.0f;
+        settings.DifferentialRatio = 3.5f;
+
+        Assert.That(settings.DrivenWheel, Is.EqualTo(1u));
+        Assert.That(settings.Wheels, Is.Not.Null);
+        Assert.That(settings.Wheels!.Length, Is.EqualTo(4));
+        Assert.That(settings.Wheels[0], Is.EqualTo(0u));
+        Assert.That(settings.Wheels[3], Is.EqualTo(3u));
+        Assert.That(settings.Inertia, Is.EqualTo(5.0f));
+        Assert.That(settings.DifferentialRatio, Is.EqualTo(3.5f));
+    }
+
+    [Test]
+    public void TestVehicleTrackSettingsNullWheels()
+    {
+        VehicleTrackSettings settings = default;
+        Assert.That(settings.Wheels, Is.Null);
+        Assert.That(settings.DrivenWheel, Is.EqualTo(0u));
+    }
+
+    [Test]
+    public void TestWheelSettingsTV()
+    {
+        using WheelSettingsTV settings = new();
+
+        // Test default values and property access
+        float longitudinalFriction = settings.LongitudinalFriction;
+        float lateralFriction = settings.LateralFriction;
+
+        Assert.That(longitudinalFriction, Is.GreaterThanOrEqualTo(0f));
+        Assert.That(lateralFriction, Is.GreaterThanOrEqualTo(0f));
+
+        // Test setters
+        settings.LongitudinalFriction = 2.0f;
+        settings.LateralFriction = 1.5f;
+
+        Assert.That(settings.LongitudinalFriction, Is.EqualTo(2.0f));
+        Assert.That(settings.LateralFriction, Is.EqualTo(1.5f));
+    }
+
+    [Test]
+    public void TestTrackedVehicleControllerSettings()
+    {
+        using TrackedVehicleControllerSettings settings = new();
+
+        // Test Engine property
+        VehicleEngineSettings engine = settings.Engine;
+        Assert.That(engine.MaxRPM, Is.GreaterThan(0f));
+
+        // Test Transmission property
+        VehicleTransmissionSettings transmission = settings.Transmission;
+        Assert.That(transmission, Is.Not.Null);
+    }
+}


### PR DESCRIPTION
- Add TrackSide enum for left/right track selection
- Add VehicleTrackSettings struct with native initialization support
- Add VehicleTrack class for runtime track property access
- Add TrackedVehicleController.GetTrack(), LeftTrack, RightTrack
- Add VehicleConstraint.LocalForward, LocalUp, WorldUp properties
- Add VehicleTests for new functionality

Generated with [Claude Code](https://claude.ai/code) via [Happy](https://happy.engineering)